### PR TITLE
fix not present proxies on removals Fix #172

### DIFF
--- a/ncollide_geometry/partitioning/bvt.rs
+++ b/ncollide_geometry/partitioning/bvt.rs
@@ -65,7 +65,7 @@ impl<B, BV> BVT<B, BV> {
         }
     }
 
-    /// Visits the bounding volume traversal tree implicitely formed with `other`.
+    /// Visits the bounding volume traversal tree implicitly formed with `other`.
     pub fn visit_bvtt<Vis: BVTTVisitor<B, BV>>(&self, other: &BVT<B, BV>, visitor: &mut Vis) {
         match (&self.tree, &other.tree) {
             (&Some(ref ta), &Some(ref tb)) => ta.visit_bvtt(tb, visitor),

--- a/ncollide_geometry/partitioning/dbvt2.rs
+++ b/ncollide_geometry/partitioning/dbvt2.rs
@@ -137,6 +137,7 @@ impl<P: Point, B, BV: BoundingVolume<P>> DBVT2<P, B, BV> {
     pub fn insert(&mut self, leaf: DBVTLeaf2<P, B, BV>) -> DBVTLeafId {
         if self.is_empty() {
             let new_id = self.leaves.push(leaf);
+            self.leaves[new_id].parent = DBVTInternalId::Root;
             self.root  = DBVTNodeId::Leaf(new_id);
 
             return DBVTLeafId(new_id);

--- a/ncollide_geometry/partitioning/dbvt2.rs
+++ b/ncollide_geometry/partitioning/dbvt2.rs
@@ -1,0 +1,310 @@
+use std::ops::Index;
+
+use na;
+
+use utils::data::SparseVec;
+use math::Point;
+use partitioning::BVTVisitor;
+use bounding_volume::BoundingVolume;
+
+#[derive(Copy, Clone, Debug, Hash)]
+pub struct DBVTLeafId(usize);
+
+impl DBVTLeafId {
+    /// Creates an invalid identifier.
+    #[inline]
+    pub fn new_invalid() -> Self {
+        DBVTLeafId(usize::max_value())
+    }
+
+    /// Checkis if this identifier is invalid.
+    #[inline]
+    pub fn is_invalid(&self) -> bool {
+        let DBVTLeafId(val) = *self;
+        val == usize::max_value()
+    }
+}
+
+#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
+enum UpdateStatus {
+    NeedsShrink,
+    UpToDate
+}
+
+#[derive(Copy, Clone, Debug, Hash)]
+enum DBVTInternalId {
+    RightChildOf(usize),
+    LeftChildOf(usize),
+    Root
+}
+
+#[derive(Copy, Clone, Debug, Hash)]
+enum DBVTNodeId {
+    Leaf(usize),
+    Internal(usize)
+}
+
+pub struct DBVT2<P, B, BV> {
+    root:      DBVTNodeId,
+    leaves:    SparseVec<DBVTLeaf2<P, B, BV>>,
+    internals: SparseVec<DBVTInternal<P, BV>>,
+}
+
+/// Leaf of a Dynamic Bounding Volume Tree.
+#[derive(Clone)]
+pub struct DBVTLeaf2<P, B, BV> {
+    /// The bounding volume of this node.
+    pub bounding_volume: BV,
+    /// The center of this node bounding volume.
+    pub center:          P,
+    /// An user-defined data.
+    pub data:            B,
+    /// This node parent.
+    parent:              DBVTInternalId
+}
+
+/// Internal node of a DBVT. An internal node always has two children.
+struct DBVTInternal<P, BV> {
+    /// The bounding volume of this node. It always encloses both its children bounding volumes.
+    bounding_volume: BV,
+    /// The center of this node bounding volume.
+    center:          P,
+    /// This node left child.
+    left:            DBVTNodeId,
+    /// This node right child.
+    right:           DBVTNodeId,
+    /// This node parent.
+    parent:          DBVTInternalId,
+
+    state:           UpdateStatus
+}
+
+impl<P: Point, B, BV: BoundingVolume<P>> DBVTLeaf2<P, B, BV> {
+    /// Creates a new DBVT leaf from its bounding volume and contained data.
+    pub fn new(bounding_volume: BV, data: B) -> DBVTLeaf2<P, B, BV> {
+        DBVTLeaf2 {
+            center:          bounding_volume.center(),
+            bounding_volume: bounding_volume,
+            data:            data,
+            parent:          DBVTInternalId::Root
+        }
+    }
+
+    /// Returns `true` if this leaf is the root of the tree, or if it detached from any tree.
+    pub fn is_root(&self) -> bool {
+        match self.parent {
+            DBVTInternalId::Root => true,
+            _                    => false
+        }
+    }
+}
+
+impl<P: Point, BV: BoundingVolume<P>> DBVTInternal<P, BV> {
+    /// Creates a new internal node.
+    fn new(bounding_volume: BV,
+           parent:          DBVTInternalId,
+           left:            DBVTNodeId,
+           right:           DBVTNodeId)
+           -> DBVTInternal<P, BV> {
+        DBVTInternal {
+            center:          bounding_volume.center(),
+            bounding_volume: bounding_volume,
+            left:            left,
+            right:           right,
+            parent:          parent,
+            state:           UpdateStatus::UpToDate
+        }
+    }
+}
+
+
+impl<P: Point, B, BV: BoundingVolume<P>> DBVT2<P, B, BV> {
+    pub fn new() -> DBVT2<P, B, BV> {
+        DBVT2 {
+            root:      DBVTNodeId::Leaf(0),
+            leaves:    SparseVec::new(),
+            internals: SparseVec::new()
+        }
+    }
+
+    /// Indicates whether this DBVT empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+
+    /// Inserts a leaf into this DBVT.
+    pub fn insert(&mut self, leaf: DBVTLeaf2<P, B, BV>) -> DBVTLeafId {
+        if self.is_empty() {
+            let new_id = self.leaves.push(leaf);
+            self.root  = DBVTNodeId::Leaf(new_id);
+
+            return DBVTLeafId(new_id);
+        }
+
+        match self.root {
+            DBVTNodeId::Internal(_) => {
+                let mut curr = self.root;
+
+                loop {
+                    match curr {
+                        DBVTNodeId::Internal(id) => {
+                            // FIXME: we could avoid the systematic merge
+                            let (left, right) = {
+                                let node = &mut self.internals[id];
+                                node.bounding_volume.merge(&leaf.bounding_volume);
+                                (node.left, node.right)
+                            };
+
+                            let dist1 = match left {
+                                DBVTNodeId::Leaf(l)     => na::distance_squared(&self.leaves[l].center, &leaf.center),
+                                DBVTNodeId::Internal(i) => na::distance_squared(&self.internals[i].center, &leaf.center),
+                            };
+
+                            let dist2 = match right {
+                                DBVTNodeId::Leaf(l)     => na::distance_squared(&self.leaves[l].center, &leaf.center),
+                                DBVTNodeId::Internal(i) => na::distance_squared(&self.internals[i].center, &leaf.center),
+                            };
+
+
+                            curr = if dist1 < dist2 { left } else { right };
+
+                        },
+                        DBVTNodeId::Leaf(id) => {
+                            let parent_bv    = self.leaves[id].bounding_volume.merged(&leaf.bounding_volume);
+                            let grand_parent = self.leaves[id].parent;
+
+                            let new_id = self.leaves.push(leaf);
+                            let parent = DBVTInternal::new(parent_bv, grand_parent, curr, DBVTNodeId::Leaf(new_id));
+                            let parent_id = self.internals.push(parent);
+                            self.leaves[id].parent     = DBVTInternalId::LeftChildOf(parent_id);
+                            self.leaves[new_id].parent = DBVTInternalId::RightChildOf(parent_id);
+
+                            match grand_parent {
+                                DBVTInternalId::LeftChildOf(pp)  => self.internals[pp].left  = DBVTNodeId::Internal(parent_id),
+                                DBVTInternalId::RightChildOf(pp) => self.internals[pp].right = DBVTNodeId::Internal(parent_id),
+                                _ => unreachable!()
+                            }
+
+                            break DBVTLeafId(new_id);
+                        }
+                    }
+                }
+            },
+            DBVTNodeId::Leaf(id) => {
+                let new_id = self.leaves.push(leaf);
+
+                // Create a common parent which is the new root.
+                let root_bv = self.leaves[id].bounding_volume.merged(&self.leaves[new_id].bounding_volume);
+                let root = DBVTInternal::new(root_bv,
+                                             DBVTInternalId::Root,
+                                             DBVTNodeId::Leaf(id),
+                                             DBVTNodeId::Leaf(new_id));
+
+                let root_id = self.internals.push(root);
+                self.leaves[id].parent     = DBVTInternalId::LeftChildOf(root_id);
+                self.leaves[new_id].parent = DBVTInternalId::RightChildOf(root_id);
+                self.root = DBVTNodeId::Internal(root_id);
+
+                DBVTLeafId(new_id)
+            }
+        }
+    }
+
+    /// Removes a leaf from this DBVT.
+    ///
+    /// Panics if the provided leaf is not attached to this DBVT.
+    pub fn remove(&mut self, leaf_id: DBVTLeafId) -> DBVTLeaf2<P, B, BV> {
+        let DBVTLeafId(leaf_id) = leaf_id;
+        let leaf = self.leaves.remove(leaf_id).expect("Attempted to remove a node not on this tree.");
+
+        if !leaf.is_root() {
+            let p;
+            let other;
+
+            match leaf.parent {
+                DBVTInternalId::RightChildOf(parent) => {
+                    other = self.internals[parent].left;
+                    p     = parent;
+                },
+                DBVTInternalId::LeftChildOf(parent) => {
+                    other = self.internals[parent].right;
+                    p     = parent;
+                },
+                DBVTInternalId::Root => unreachable!()
+            }
+
+            match self.internals[p].parent {
+                DBVTInternalId::RightChildOf(pp) => {
+                    match other {
+                        DBVTNodeId::Internal(id) => self.internals[id].parent = DBVTInternalId::RightChildOf(pp),
+                        DBVTNodeId::Leaf(id)     => self.leaves[id].parent    = DBVTInternalId::RightChildOf(pp)
+                    }
+
+                    self.internals[pp].right = other;
+                    self.internals[pp].state = UpdateStatus::NeedsShrink;
+                },
+                DBVTInternalId::LeftChildOf(pp) => {
+                    match other {
+                        DBVTNodeId::Internal(id) => self.internals[id].parent = DBVTInternalId::LeftChildOf(pp),
+                        DBVTNodeId::Leaf(id)     => self.leaves[id].parent    = DBVTInternalId::LeftChildOf(pp)
+                    }
+
+                    self.internals[pp].left = other;
+                    self.internals[pp].state = UpdateStatus::NeedsShrink;
+                },
+                DBVTInternalId::Root => {
+                    // The root changes to the other child.
+                    match other {
+                        DBVTNodeId::Leaf(id)     => self.leaves[id].parent    = DBVTInternalId::Root,
+                        DBVTNodeId::Internal(id) => self.internals[id].parent = DBVTInternalId::Root,
+                    }
+
+                    self.root = other;
+                }
+            }
+        }
+        else {
+            // The tree is now empty.
+            self.leaves.clear();
+            self.internals.clear();
+        }
+
+        leaf
+    }
+
+    /// Traverses this tree using an object implementing the `BVTVisitor`trait.
+    ///
+    /// This will traverse the whole tree and call the visitor `.visit_internal(...)` (resp.
+    /// `.visit_leaf(...)`) method on each internal (resp. leaf) node.
+    pub fn visit<Vis: BVTVisitor<B, BV>>(&self, visitor: &mut Vis) {
+        if !self.is_empty() {
+            self.visit_node(visitor, self.root);
+        }
+    }
+
+    fn visit_node<Vis: BVTVisitor<B, BV>>(&self, visitor: &mut Vis, node: DBVTNodeId) {
+        match node {
+            DBVTNodeId::Internal(i) => {
+                let internal = &self.internals[i];
+                if visitor.visit_internal(&internal.bounding_volume) {
+                    self.visit_node(visitor, internal.left);
+                    self.visit_node(visitor, internal.right);
+                }
+            },
+            DBVTNodeId::Leaf(i) => {
+                let leaf = &self.leaves[i];
+                visitor.visit_leaf(&leaf.data, &leaf.bounding_volume);
+            }
+        }
+    }
+}
+
+impl<P, B, BV> Index<DBVTLeafId> for DBVT2<P, B, BV> {
+    type Output = DBVTLeaf2<P, B, BV>;
+
+    #[inline]
+    fn index(&self, DBVTLeafId(id): DBVTLeafId) -> &Self::Output {
+        &self.leaves[id]
+    }
+}

--- a/ncollide_geometry/partitioning/mod.rs
+++ b/ncollide_geometry/partitioning/mod.rs
@@ -1,5 +1,6 @@
 //! Spatial partitioning tools.
 
+pub use partitioning::dbvt2::{DBVT2, DBVTLeaf2, DBVTLeafId};
 pub use partitioning::dbvt::{DBVT, DBVTLeaf};
 pub use partitioning::bvt::{BVT, BinaryPartition, BVTNode};
 #[doc(inline)]
@@ -10,6 +11,7 @@ pub use partitioning::bvtt_visitor::BVTTVisitor;
 pub use partitioning::bvt_cost_fn::BVTCostFn;
 
 mod dbvt;
+mod dbvt2;
 mod bvt;
 
 #[doc(hidden)]

--- a/ncollide_geometry/query/algorithms/simplex.rs
+++ b/ncollide_geometry/query/algorithms/simplex.rs
@@ -1,9 +1,10 @@
 //! Abstract definition of a simplex usable by the GJK algorithm.
 
+use std::any::Any;
 use math::Point;
 
 /// Trait of a simplex usable by the GJK algorithm.
-pub trait Simplex<P: Point> {
+pub trait Simplex<P: Point>: Any + Send + Sync {
     /// Replace the point of the simplex by a single one. The simplex is reduced to be
     /// 0-dimensional.
     fn reset(&mut self, P);

--- a/ncollide_pipeline/broad_phase/broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/broad_phase.rs
@@ -1,12 +1,15 @@
+use std::any::Any;
 use geometry::query::Ray;
 use math::Point;
 
 /// Trait all broad phase must implement.
-pub trait BroadPhase<P: Point, BV, T> {
+pub trait BroadPhase<P: Point, BV, T>: Any + Sync + Send {
     /// Tells the broad phase to add an element during the next update.
+    ///
+    /// If the element already exists, it is replaced.
     fn deferred_add(&mut self, uid: usize, bv: BV, data: T);
 
-    /// Tells the broad phase to remove an element during the next update.
+    /// Tells the broad phase to remove an element during the next update if it exists.
     fn deferred_remove(&mut self, uid: usize);
 
     /// Sets the next bounding volume to be used during the update of this broad phase.
@@ -16,7 +19,9 @@ pub trait BroadPhase<P: Point, BV, T> {
     fn deferred_recompute_all_proximities(&mut self);
 
     /// Updates the object additions, removals, and interferences detection.
-    fn update(&mut self, allow_proximity: &mut FnMut(&T, &T) -> bool, proximity_handler: &mut FnMut(&T, &T, bool));
+    fn update(&mut self,
+              allow_proximity:   &mut FnMut(&T, &T) -> bool,
+              proximity_handler: &mut FnMut(&T, &T, bool));
 
     /*
      * FIXME: the following are not flexible enough.

--- a/ncollide_pipeline/broad_phase/broad_phase_pair_filter.rs
+++ b/ncollide_pipeline/broad_phase/broad_phase_pair_filter.rs
@@ -1,8 +1,10 @@
+use std::any::Any;
+
 use world::CollisionObject;
 use math::Point;
 
 /// A signal handler for contact detection.
-pub trait BroadPhasePairFilter<P: Point, M, T> {
+pub trait BroadPhasePairFilter<P: Point, M, T>: Any + Send + Sync {
     /// Activate an action for when two objects start or stop to be close to each other.
     fn is_pair_valid(&self, b1: &CollisionObject<P, M, T>, b2: &CollisionObject<P, M, T>) -> bool;
 }
@@ -11,7 +13,7 @@ pub trait BroadPhasePairFilter<P: Point, M, T> {
 ///
 /// All filters have have to return `true` in order to allow a proximity to be further handled.
 pub struct BroadPhasePairFilters<P: Point, M, T> {
-    filters: Vec<(String, Box<BroadPhasePairFilter<P, M, T> + 'static>)>,
+    filters: Vec<(String, Box<BroadPhasePairFilter<P, M, T>>)>,
 }
 
 impl<P: Point, M, T> BroadPhasePairFilters<P, M, T> {
@@ -23,7 +25,7 @@ impl<P: Point, M, T> BroadPhasePairFilters<P, M, T> {
     }
 
     /// Registers a collision filter.
-    pub fn register_collision_filter(&mut self, name: &str, callback: Box<BroadPhasePairFilter<P, M, T> + 'static>) {
+    pub fn register_collision_filter(&mut self, name: &str, callback: Box<BroadPhasePairFilter<P, M, T>>) {
         for &mut (ref mut n, ref mut f) in self.filters.iter_mut() {
             if name == &n[..] {
                 *f = callback;

--- a/ncollide_pipeline/broad_phase/brute_force_broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/brute_force_broad_phase.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use alga::general::Id;
 use utils::data::uid_remap::{UidRemap, FastKey};
 use geometry::bounding_volume::BoundingVolume;
@@ -30,8 +32,9 @@ impl<N, BV, T> BruteForceBroadPhase<N, BV, T> {
 }
 
 impl<P: Point, BV, T> BroadPhase<P, BV, T> for BruteForceBroadPhase<P::Real, BV, T> where
-    BV: 'static + BoundingVolume<P> +
-        RayCast<P, Id> + PointQuery<P, Id> + Clone {
+    BV: BoundingVolume<P> + RayCast<P, Id> + PointQuery<P, Id> + 
+        Any + Send + Sync + Clone,
+    T: Any + Send + Sync {
     fn deferred_add(&mut self, uid: usize, bv: BV, data: T) {
         // XXX: should not be inserted now!
         let (key, _) = self.proxies.insert(uid, (bv.clone(), data));

--- a/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/ncollide_pipeline/broad_phase/dbvt_broad_phase.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -73,301 +74,301 @@ impl<P, BV, T> DBVTBroadPhase<P, BV, T>
     }
 }
 
-impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
-    where P:  Point,
-          BV: 'static + BoundingVolume<P> +
-              RayCast<P, Id> + PointQuery<P, Id> + Clone {
-    #[inline]
-    fn deferred_add(&mut self, uid: usize, bv: BV, data: T) {
-        self.to_add.push((uid, bv, data));
-    }
-
-    fn deferred_remove(&mut self, uid: usize) {
-        let proxy_key = match self.proxies.get_fast_key(uid) {
-            None      => return,
-            Some(uid) => uid
-        };
-
-        {
-            let proxy = self.proxies.get_fast_mut(&proxy_key).unwrap();
-
-            match proxy.active {
-                // Already removed.
-                REMOVE_FROM_TREE | REMOVE_FROM_STREE => { },
-                // To remove from the static tree.
-                0 => proxy.active = REMOVE_FROM_STREE,
-                // To remove from the dynamic tree.
-                _ => proxy.active = REMOVE_FROM_TREE
-            }
-
-            self.purge_all = true;
-        }
-
-        self.proxies_to_remove.push(uid);
-    }
-
-    fn update(&mut self, allow_proximity: &mut FnMut(&T, &T) -> bool, handler: &mut FnMut(&T, &T, bool)) {
-        /*
-         * Perform additions.
-         */
-        for (uid, bv, data) in self.to_add.drain(..) {
-            let lbv = bv.loosened(self.margin.clone());
-            let leaf: DBVTLeaf<P, FastKey, BV> = DBVTLeaf::new(lbv.clone(), FastKey::new_invalid());
-            let leaf = Rc::new(RefCell::new(leaf));
-            let proxy = DBVTBroadPhaseProxy {
-                data:   data,
-                leaf:   leaf.clone(),
-                active: DEACTIVATION_THRESHOLD
-            };
-
-            let (proxy_key, _) = self.proxies.insert(uid, proxy);
-            leaf.borrow_mut().object = proxy_key.clone();
-            self.to_update.push((proxy_key, lbv));
-        }
-
-        /*
-         * Remove all the outdated nodes.
-         */
-        for &(ref id, ref bv) in self.to_update.iter().rev() {
-            // FIXME: the `None` case may actually happen if the object is updated, then
-            // removed, then the broad phase is updated.
-            let proxy = self.proxies.get_fast_mut(id).expect("The proxy was not valid.");
-
-            // If the activation number is < than the threshold then the leaf has not been removed
-            // yet.
-            if proxy.active == 0 {
-                proxy.leaf.borrow_mut().bounding_volume = bv.clone();
-                self.stree.remove(&mut proxy.leaf);
-                proxy.active = DEACTIVATION_THRESHOLD;
-            }
-            else if proxy.active == REMOVE_FROM_TREE {
-                self.tree.remove(&mut proxy.leaf);
-            }
-            else if proxy.active == REMOVE_FROM_STREE {
-                self.stree.remove(&mut proxy.leaf);
-            }
-            else if proxy.active < DEACTIVATION_THRESHOLD {
-                proxy.leaf.borrow_mut().bounding_volume = bv.clone();
-                self.tree.remove(&mut proxy.leaf);
-                proxy.active = DEACTIVATION_THRESHOLD;
-            }
-        }
-
-        /*
-         * Re-insert outdated nodes one by one and collect interferences at the same time.
-         */
-        for &(ref proxy_key1, _) in self.to_update.iter().rev() {
-            let proxy1 = &self.proxies[*proxy_key1];
-
-            if !proxy1.leaf.borrow().is_detached() {
-                continue;
-            }
-
-            if proxy1.active < 0 {
-                continue;
-            }
-
-            {
-                let node1 = proxy1.leaf.borrow();
-                let mut visitor = BoundingVolumeInterferencesCollector::new(
-                    &node1.bounding_volume,
-                    &mut self.collector);
-
-                self.tree.visit(&mut visitor);
-                self.stree.visit(&mut visitor);
-            }
-
-            // Event generation.
-            for proxy_key2 in self.collector.iter() {
-                let proxy2 = &self.proxies[*proxy_key2];
-                let filtered_out = proxy2.active < 0 || !allow_proximity(&proxy1.data, &proxy2.data);
-
-                if !filtered_out {
-                    let mut trigger = false;
-
-                    let _ = self.pairs.find_or_insert_lazy(
-                        Pair::new(*proxy_key1, *proxy_key2),
-                        || { trigger = true; Some(()) });
-
-                    if trigger {
-                        handler(&proxy1.data, &proxy2.data, true)
-                    }
-                }
-            }
-
-            self.collector.clear();
-            self.tree.insert(proxy1.leaf.clone());
-        }
-
-        /*
-         * Remove some of the outdated collisions.
-         */
-        // NOTE: the exact same code is used on `brute_force_bounding_volume_broad_phase.rs`.
-        // Refactor that?
-        if self.purge_all || (self.to_update.len() != 0 && self.pairs.len() != 0) {
-            let len = self.pairs.len();
-            let num_removals;
-
-            if self.purge_all {
-                self.update_off = 0;
-                num_removals = len;
-                self.purge_all = false;
-            }
-            else {
-                num_removals = *na::clamp(&(self.to_update.len()), &(len / 10), &len);
-            }
-
-            for i in self.update_off .. self.update_off + num_removals {
-                let id   = i % self.pairs.len();
-                let elts = self.pairs.elements();
-                let ids  = elts[id].key;
-
-                let remove = {
-                    let proxy1 = &self.proxies[ids.first];
-                    let proxy2 = &self.proxies[ids.second];
-
-                    let bv1 = &proxy1.leaf.borrow().bounding_volume;
-                    let bv2 = &proxy2.leaf.borrow().bounding_volume;
-
-                    let filtered_out = proxy1.active < 0 ||
-                                       proxy2.active < 0 ||
-                                       !allow_proximity(&proxy1.data, &proxy2.data);
-
-                    if filtered_out || !bv1.intersects(bv2) {
-                        handler(&proxy1.data, &proxy2.data, false);
-
-                        true
-                    }
-                    else {
-                        false
-                    }
-                };
-
-                if remove {
-                    self.pairs_to_remove.push(ids);
-                }
-            }
-
-            self.update_off = if self.pairs.len() != 0 {
-                (self.update_off + num_removals) % self.pairs.len()
-            } else {
-                0
-            };
-        }
-
-        self.to_update.clear();
-
-        /*
-         * Actually remove the pairs.
-         */
-        for pair in self.pairs_to_remove.iter() {
-            let _ = self.pairs.remove(pair);
-        }
-        self.pairs_to_remove.clear();
-
-        /*
-         * Update activation states.
-         * FIXME: could we avoid having to iterate through _all_ the proxies at each update?
-         * (for example, using a timestamp instead of a counter).
-         */
-        for (_, proxy) in self.proxies.iter_mut() {
-            if proxy.active == 1 {
-                proxy.active = 0;
-                self.tree.remove(&mut proxy.leaf);
-                self.stree.insert(proxy.leaf.clone());
-            }
-            else if proxy.active > 1 {
-                proxy.active = proxy.active - 1;
-            }
-        }
-
-        for uid in self.proxies_to_remove.iter() {
-            if let Some((_, mut proxy)) = self.proxies.remove(*uid) {
-                if proxy.active == REMOVE_FROM_TREE {
-                    self.tree.remove(&mut proxy.leaf);
-                }
-                else {
-                    assert!(proxy.active == REMOVE_FROM_STREE);
-                    self.stree.remove(&mut proxy.leaf);
-                }
-            }
-        }
-
-        self.proxies_to_remove.clear();
-    }
-
-    fn deferred_set_bounding_volume(&mut self, uid: usize, bounding_volume: BV) {
-        if let Some(proxy_key) = self.proxies.get_fast_key(uid) {
-            let proxy = self.proxies.get_fast_mut(&proxy_key).unwrap();
-
-            if proxy.active >= 0 {
-                let needs_update = !proxy.leaf.borrow().bounding_volume.contains(&bounding_volume);
-
-                if needs_update {
-                    self.to_update.push((proxy_key, bounding_volume.loosened(self.margin)));
-                }
-                else if proxy.active != DEACTIVATION_THRESHOLD { // If == the object might already be on the update list.
-                    if proxy.active == 0 {
-                        self.stree.remove(&mut proxy.leaf);
-                        self.tree.insert(proxy.leaf.clone());
-                    }
-
-                    proxy.active = DEACTIVATION_THRESHOLD - 1;
-                }
-            }
-        }
-    }
-
-    fn deferred_recompute_all_proximities(&mut self) {
-        for proxy in self.proxies.iter() {
-            if proxy.1.active >= 0 {
-                self.to_update.push((proxy.0, proxy.1.leaf.borrow().bounding_volume.clone()));
-            }
-        }
-    }
-
-    fn interferences_with_bounding_volume<'a>(&'a self, bv: &BV, out: &mut Vec<&'a T>) {
-        let mut collector = Vec::new();
-
-        {
-            let mut visitor = BoundingVolumeInterferencesCollector::new(bv, &mut collector);
-
-            self.tree.visit(&mut visitor);
-            self.stree.visit(&mut visitor);
-        }
-
-        for l in collector.into_iter() {
-            out.push(&self.proxies[l].data)
-        }
-    }
-
-    fn interferences_with_ray<'a>(&'a self, ray: &Ray<P>, out: &mut Vec<&'a T>) {
-        let mut collector = Vec::new();
-
-        {
-            let mut visitor = RayInterferencesCollector::new(ray, &mut collector);
-
-            self.tree.visit(&mut visitor);
-            self.stree.visit(&mut visitor);
-        }
-
-        for l in collector.into_iter() {
-            out.push(&self.proxies[l].data)
-        }
-    }
-
-    fn interferences_with_point<'a>(&'a self, point: &P, out: &mut Vec<&'a T>) {
-        let mut collector = Vec::new();
-
-        {
-            let mut visitor = PointInterferencesCollector::new(point, &mut collector);
-
-            self.tree.visit(&mut visitor);
-            self.stree.visit(&mut visitor);
-        }
-
-        for l in collector.into_iter() {
-            out.push(&self.proxies[l].data)
-        }
-    }
-}
+// impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
+//     where P:  Point,
+//           BV: BoundingVolume<P> + RayCast<P, Id> + PointQuery<P, Id> + Any + Send + Sync + Clone,
+//           T:  Any + Send + Sync {
+//     #[inline]
+//     fn deferred_add(&mut self, uid: usize, bv: BV, data: T) {
+//         self.to_add.push((uid, bv, data));
+//     }
+// 
+//     fn deferred_remove(&mut self, uid: usize) {
+//         let proxy_key = match self.proxies.get_fast_key(uid) {
+//             None      => return,
+//             Some(uid) => uid
+//         };
+// 
+//         {
+//             let proxy = self.proxies.get_fast_mut(&proxy_key).unwrap();
+// 
+//             match proxy.active {
+//                 // Already removed.
+//                 REMOVE_FROM_TREE | REMOVE_FROM_STREE => { },
+//                 // To remove from the static tree.
+//                 0 => proxy.active = REMOVE_FROM_STREE,
+//                 // To remove from the dynamic tree.
+//                 _ => proxy.active = REMOVE_FROM_TREE
+//             }
+// 
+//             self.purge_all = true;
+//         }
+// 
+//         self.proxies_to_remove.push(uid);
+//     }
+// 
+//     fn update(&mut self, allow_proximity: &mut FnMut(&T, &T) -> bool, handler: &mut FnMut(&T, &T, bool)) {
+//         /*
+//          * Perform additions.
+//          */
+//         for (uid, bv, data) in self.to_add.drain(..) {
+//             let lbv = bv.loosened(self.margin.clone());
+//             let leaf: DBVTLeaf<P, FastKey, BV> = DBVTLeaf::new(lbv.clone(), FastKey::new_invalid());
+//             let leaf = Rc::new(RefCell::new(leaf));
+//             let proxy = DBVTBroadPhaseProxy {
+//                 data:   data,
+//                 leaf:   leaf.clone(),
+//                 active: DEACTIVATION_THRESHOLD
+//             };
+// 
+//             let (proxy_key, _) = self.proxies.insert(uid, proxy);
+//             leaf.borrow_mut().object = proxy_key.clone();
+//             self.to_update.push((proxy_key, lbv));
+//         }
+// 
+//         /*
+//          * Remove all the outdated nodes.
+//          */
+//         for &(ref id, ref bv) in self.to_update.iter().rev() {
+//             // FIXME: the `None` case may actually happen if the object is updated, then
+//             // removed, then the broad phase is updated.
+//             let proxy = self.proxies.get_fast_mut(id).expect("The proxy was not valid.");
+// 
+//             // If the activation number is < than the threshold then the leaf has not been removed
+//             // yet.
+//             if proxy.active == 0 {
+//                 proxy.leaf.borrow_mut().bounding_volume = bv.clone();
+//                 self.stree.remove(&mut proxy.leaf);
+//                 proxy.active = DEACTIVATION_THRESHOLD;
+//             }
+//             else if proxy.active == REMOVE_FROM_TREE {
+//                 self.tree.remove(&mut proxy.leaf);
+//             }
+//             else if proxy.active == REMOVE_FROM_STREE {
+//                 self.stree.remove(&mut proxy.leaf);
+//             }
+//             else if proxy.active < DEACTIVATION_THRESHOLD {
+//                 proxy.leaf.borrow_mut().bounding_volume = bv.clone();
+//                 self.tree.remove(&mut proxy.leaf);
+//                 proxy.active = DEACTIVATION_THRESHOLD;
+//             }
+//         }
+// 
+//         /*
+//          * Re-insert outdated nodes one by one and collect interferences at the same time.
+//          */
+//         for &(ref proxy_key1, _) in self.to_update.iter().rev() {
+//             let proxy1 = &self.proxies[*proxy_key1];
+// 
+//             if !proxy1.leaf.borrow().is_detached() {
+//                 continue;
+//             }
+// 
+//             if proxy1.active < 0 {
+//                 continue;
+//             }
+// 
+//             {
+//                 let node1 = proxy1.leaf.borrow();
+//                 let mut visitor = BoundingVolumeInterferencesCollector::new(
+//                     &node1.bounding_volume,
+//                     &mut self.collector);
+// 
+//                 self.tree.visit(&mut visitor);
+//                 self.stree.visit(&mut visitor);
+//             }
+// 
+//             // Event generation.
+//             for proxy_key2 in self.collector.iter() {
+//                 let proxy2 = &self.proxies[*proxy_key2];
+//                 let filtered_out = proxy2.active < 0 || !allow_proximity(&proxy1.data, &proxy2.data);
+// 
+//                 if !filtered_out {
+//                     let mut trigger = false;
+// 
+//                     let _ = self.pairs.find_or_insert_lazy(
+//                         Pair::new(*proxy_key1, *proxy_key2),
+//                         || { trigger = true; Some(()) });
+// 
+//                     if trigger {
+//                         handler(&proxy1.data, &proxy2.data, true)
+//                     }
+//                 }
+//             }
+// 
+//             self.collector.clear();
+//             self.tree.insert(proxy1.leaf.clone());
+//         }
+// 
+//         /*
+//          * Remove some of the outdated collisions.
+//          */
+//         // NOTE: the exact same code is used on `brute_force_bounding_volume_broad_phase.rs`.
+//         // Refactor that?
+//         if self.purge_all || (self.to_update.len() != 0 && self.pairs.len() != 0) {
+//             let len = self.pairs.len();
+//             let num_removals;
+// 
+//             if self.purge_all {
+//                 self.update_off = 0;
+//                 num_removals = len;
+//                 self.purge_all = false;
+//             }
+//             else {
+//                 num_removals = *na::clamp(&(self.to_update.len()), &(len / 10), &len);
+//             }
+// 
+//             for i in self.update_off .. self.update_off + num_removals {
+//                 let id   = i % self.pairs.len();
+//                 let elts = self.pairs.elements();
+//                 let ids  = elts[id].key;
+// 
+//                 let remove = {
+//                     let proxy1 = &self.proxies[ids.first];
+//                     let proxy2 = &self.proxies[ids.second];
+// 
+//                     let bv1 = &proxy1.leaf.borrow().bounding_volume;
+//                     let bv2 = &proxy2.leaf.borrow().bounding_volume;
+// 
+//                     let filtered_out = proxy1.active < 0 ||
+//                                        proxy2.active < 0 ||
+//                                        !allow_proximity(&proxy1.data, &proxy2.data);
+// 
+//                     if filtered_out || !bv1.intersects(bv2) {
+//                         handler(&proxy1.data, &proxy2.data, false);
+// 
+//                         true
+//                     }
+//                     else {
+//                         false
+//                     }
+//                 };
+// 
+//                 if remove {
+//                     self.pairs_to_remove.push(ids);
+//                 }
+//             }
+// 
+//             self.update_off = if self.pairs.len() != 0 {
+//                 (self.update_off + num_removals) % self.pairs.len()
+//             } else {
+//                 0
+//             };
+//         }
+// 
+//         self.to_update.clear();
+// 
+//         /*
+//          * Actually remove the pairs.
+//          */
+//         for pair in self.pairs_to_remove.iter() {
+//             let _ = self.pairs.remove(pair);
+//         }
+//         self.pairs_to_remove.clear();
+// 
+//         /*
+//          * Update activation states.
+//          * FIXME: could we avoid having to iterate through _all_ the proxies at each update?
+//          * (for example, using a timestamp instead of a counter).
+//          */
+//         for (_, proxy) in self.proxies.iter_mut() {
+//             if proxy.active == 1 {
+//                 proxy.active = 0;
+//                 self.tree.remove(&mut proxy.leaf);
+//                 self.stree.insert(proxy.leaf.clone());
+//             }
+//             else if proxy.active > 1 {
+//                 proxy.active = proxy.active - 1;
+//             }
+//         }
+// 
+//         for uid in self.proxies_to_remove.iter() {
+//             if let Some((_, mut proxy)) = self.proxies.remove(*uid) {
+//                 if proxy.active == REMOVE_FROM_TREE {
+//                     self.tree.remove(&mut proxy.leaf);
+//                 }
+//                 else {
+//                     assert!(proxy.active == REMOVE_FROM_STREE);
+//                     self.stree.remove(&mut proxy.leaf);
+//                 }
+//             }
+//         }
+// 
+//         self.proxies_to_remove.clear();
+//     }
+// 
+//     fn deferred_set_bounding_volume(&mut self, uid: usize, bounding_volume: BV) {
+//         if let Some(proxy_key) = self.proxies.get_fast_key(uid) {
+//             let proxy = self.proxies.get_fast_mut(&proxy_key).unwrap();
+// 
+//             if proxy.active >= 0 {
+//                 let needs_update = !proxy.leaf.borrow().bounding_volume.contains(&bounding_volume);
+// 
+//                 if needs_update {
+//                     self.to_update.push((proxy_key, bounding_volume.loosened(self.margin)));
+//                 }
+//                 else if proxy.active != DEACTIVATION_THRESHOLD { // If == the object might already be on the update list.
+//                     if proxy.active == 0 {
+//                         self.stree.remove(&mut proxy.leaf);
+//                         self.tree.insert(proxy.leaf.clone());
+//                     }
+// 
+//                     proxy.active = DEACTIVATION_THRESHOLD - 1;
+//                 }
+//             }
+//         }
+//     }
+// 
+//     fn deferred_recompute_all_proximities(&mut self) {
+//         for proxy in self.proxies.iter() {
+//             if proxy.1.active >= 0 {
+//                 self.to_update.push((proxy.0, proxy.1.leaf.borrow().bounding_volume.clone()));
+//             }
+//         }
+//     }
+// 
+//     fn interferences_with_bounding_volume<'a>(&'a self, bv: &BV, out: &mut Vec<&'a T>) {
+//         let mut collector = Vec::new();
+// 
+//         {
+//             let mut visitor = BoundingVolumeInterferencesCollector::new(bv, &mut collector);
+// 
+//             self.tree.visit(&mut visitor);
+//             self.stree.visit(&mut visitor);
+//         }
+// 
+//         for l in collector.into_iter() {
+//             out.push(&self.proxies[l].data)
+//         }
+//     }
+// 
+//     fn interferences_with_ray<'a>(&'a self, ray: &Ray<P>, out: &mut Vec<&'a T>) {
+//         let mut collector = Vec::new();
+// 
+//         {
+//             let mut visitor = RayInterferencesCollector::new(ray, &mut collector);
+// 
+//             self.tree.visit(&mut visitor);
+//             self.stree.visit(&mut visitor);
+//         }
+// 
+//         for l in collector.into_iter() {
+//             out.push(&self.proxies[l].data)
+//         }
+//     }
+// 
+//     fn interferences_with_point<'a>(&'a self, point: &P, out: &mut Vec<&'a T>) {
+//         let mut collector = Vec::new();
+// 
+//         {
+//             let mut visitor = PointInterferencesCollector::new(point, &mut collector);
+// 
+//             self.tree.visit(&mut visitor);
+//             self.stree.visit(&mut visitor);
+//         }
+// 
+//         for l in collector.into_iter() {
+//             out.push(&self.proxies[l].data)
+//         }
+//     }
+// }

--- a/ncollide_pipeline/broad_phase/dbvt_broad_phase2.rs
+++ b/ncollide_pipeline/broad_phase/dbvt_broad_phase2.rs
@@ -1,0 +1,405 @@
+use std::any::Any;
+use std::collections::hash_map::{Entry, HashMap as StdHashMap};
+
+use alga::general::Id;
+use na;
+use utils::data::uid_remap::{UidRemap, FastKey};
+use utils::data::pair::{Pair, PairTWHash};
+use utils::data::hash_map::HashMap;
+use math::Point;
+use geometry::bounding_volume::{BoundingVolume, BoundingVolumeInterferencesCollector};
+use geometry::partitioning::{DBVT2, DBVTLeaf2, DBVTLeafId};
+use geometry::query::{Ray, RayCast, RayInterferencesCollector, PointQuery, PointInterferencesCollector};
+use broad_phase::BroadPhase;
+
+#[derive(Copy, Clone, Debug)]
+enum ProxyStatus {
+    OnStaticTree,
+    OnDynamicTree,
+    Detached
+}
+
+enum Action<BV, T> {
+    Modify(BV, Option<T>),
+    Remove(usize)
+}
+
+struct DBVTBroadPhaseProxy<T> {
+    data:   T,
+    status: usize,
+    leaf:   DBVTLeafId
+}
+
+impl<T> DBVTBroadPhaseProxy<T> {
+    fn new(data: T) -> DBVTBroadPhaseProxy<T> {
+        DBVTBroadPhaseProxy {
+            data:   data,
+            status: DEACTIVATION_THRESHOLD,
+            leaf:   DBVTLeafId::new_invalid()
+        }
+    }
+
+    fn status(&self) -> ProxyStatus {
+        if self.leaf.is_invalid() {
+            ProxyStatus::Detached
+        }
+        else if self.status == 0 {
+            ProxyStatus::OnStaticTree
+        }
+        else {
+            ProxyStatus::OnDynamicTree
+        }
+    }
+
+    fn detach(&mut self) {
+        self.leaf   = DBVTLeafId::new_invalid();
+        self.status = DEACTIVATION_THRESHOLD;
+    }
+}
+
+const DEACTIVATION_THRESHOLD: usize = 100;
+
+/// Broad phase based on a Dynamic Bounding Volume Tree.
+///
+/// It uses two separate trees: one for static objects and which is never updated, and one for
+/// moving objects.
+pub struct DBVTBroadPhase<P: Point, BV, T> {
+    proxies:       UidRemap<DBVTBroadPhaseProxy<T>>,
+    tree:          DBVT2<P, FastKey, BV>, // DBVT for moving objects.
+    stree:         DBVT2<P, FastKey, BV>, // DBVT for static objects.
+    pairs:         HashMap<Pair, (), PairTWHash>, // Pairs detected (FIXME: use a Vec instead?)
+    margin:        P::Real, // The margin added to each bounding volume.
+    update_off:    usize, // Incremental pairs removal index.
+    purge_all:     bool,
+
+    // Just to avoid dynamic allocations.
+    collector:         Vec<FastKey>,
+    pairs_to_remove:   Vec<Pair>,
+    to_update:         Vec<DBVTLeaf2<P, FastKey, BV>>,
+    actions:           StdHashMap<FastKey, Action<BV, T>>
+}
+
+impl<P, BV, T> DBVTBroadPhase<P, BV, T>
+    where P:  Point,
+          BV: 'static + BoundingVolume<P> + Clone {
+    /// Creates a new broad phase based on a Dynamic Bounding Volume Tree.
+    pub fn new(margin: P::Real, small_keys: bool) -> DBVTBroadPhase<P, BV, T> {
+        DBVTBroadPhase {
+            proxies:           UidRemap::new(small_keys),
+            tree:              DBVT2::new(),
+            stree:             DBVT2::new(),
+            pairs:             HashMap::new(PairTWHash::new()),
+            update_off:        0,
+            purge_all:         false,
+            collector:         Vec::new(),
+            to_update:         Vec::new(),
+            pairs_to_remove:   Vec::new(),
+            actions:           StdHashMap::new(),
+            margin:            margin
+        }
+    }
+
+    /// Number of interferences detected by this broad phase.
+    #[inline]
+    pub fn num_interferences(&self) -> usize {
+        self.pairs.len()
+    }
+
+    fn purge_some_contact_pairs(&mut self,
+                                allow_proximity: &mut FnMut(&T, &T) -> bool,
+                                handler:         &mut FnMut(&T, &T, bool)) {
+        // NOTE: the exact same code is used on `brute_force_bounding_volume_broad_phase.rs`.
+        // Refactor that?
+        if self.purge_all || (self.to_update.len() != 0 && self.pairs.len() != 0) {
+            let len = self.pairs.len();
+            let num_removals;
+
+            if self.purge_all {
+                self.update_off = 0;
+                num_removals = len;
+                self.purge_all = false;
+            }
+            else {
+                num_removals = *na::clamp(&(self.to_update.len()), &(len / 10), &len);
+            }
+
+            for i in self.update_off .. self.update_off + num_removals {
+                let id   = i % self.pairs.len();
+                let elts = self.pairs.elements();
+                let ids  = elts[id].key;
+
+                let mut remove = true;
+
+                let proxy1 = &self.proxies[ids.first];
+                let proxy2 = &self.proxies[ids.second];
+
+                if allow_proximity(&proxy1.data, &proxy2.data) {
+                    let l1 = if proxy1.status == 0 {
+                        &self.stree[proxy1.leaf]
+                    }
+                    else {
+                        &self.tree[proxy1.leaf]
+                    };
+
+                    let l2 = if proxy2.status == 0 {
+                        &self.stree[proxy2.leaf]
+                    }
+                    else {
+                        &self.tree[proxy2.leaf]
+                    };
+
+                    if l1.bounding_volume.intersects(&l2.bounding_volume) {
+                        remove = false
+                    }
+                }
+
+                if remove {
+                    handler(&proxy1.data, &proxy2.data, false);
+                    self.pairs_to_remove.push(ids);
+                }
+            }
+
+            self.update_off = if self.pairs.len() != 0 {
+                (self.update_off + num_removals) % self.pairs.len()
+            } else {
+                0
+            };
+        }
+
+        /*
+         * Actually remove the pairs.
+         */
+        for pair in self.pairs_to_remove.iter() {
+            let _ = self.pairs.remove(pair);
+        }
+        self.pairs_to_remove.clear();
+    }
+
+    fn update_activation_states(&mut self) {
+        /*
+         * Update activation states.
+         * FIXME: could we avoid having to iterate through _all_ the proxies at each update?
+         * (for example, using a timestamp instead of a counter).
+         */
+        for (_, proxy) in self.proxies.iter_mut() {
+            if proxy.status == 1 {
+                proxy.status = 0;
+                let leaf = self.tree.remove(proxy.leaf);
+                proxy.leaf = self.stree.insert(leaf);
+            }
+            else if proxy.status > 1 {
+                proxy.status -= 1;
+            }
+        }
+    }
+}
+
+impl<P, BV, T> BroadPhase<P, BV, T> for DBVTBroadPhase<P, BV, T>
+    where P:  Point,
+          BV: BoundingVolume<P> + RayCast<P, Id> + PointQuery<P, Id> + Any + Send + Sync + Clone,
+          T:  Any + Send + Sync {
+    fn update(&mut self, allow_proximity: &mut FnMut(&T, &T) -> bool, handler: &mut FnMut(&T, &T, bool)) {
+        /*
+         * Remove from the trees all nodes that have been deleted or modified.
+         */
+        for (proxy_key, action) in self.actions.drain() {
+            match action {
+                Action::Modify(bv, data) => {
+                    let proxy = &mut self.proxies[proxy_key];
+
+                    if let Some(data) = data {
+                        proxy.data = data;
+                    }
+
+                    match proxy.status() {
+                        ProxyStatus::OnStaticTree => {
+                            let mut leaf = self.stree.remove(proxy.leaf);
+                            leaf.bounding_volume = bv;
+                            self.to_update.push(leaf);
+                        },
+                        ProxyStatus::OnDynamicTree => {
+                            let mut leaf = self.tree.remove(proxy.leaf);
+                            leaf.bounding_volume = bv;
+                            self.to_update.push(leaf);
+                        },
+                        ProxyStatus::Detached => {
+                            let leaf = DBVTLeaf2::new(bv, proxy_key);
+                            self.to_update.push(leaf);
+                        }
+                    }
+
+                    proxy.detach();
+                }
+                Action::Remove(uid) => {
+                    if let Some((_, proxy)) = self.proxies.remove(uid) {
+                        match proxy.status() {
+                            ProxyStatus::OnStaticTree => {
+                                let _ = self.stree.remove(proxy.leaf);
+                            }
+                            ProxyStatus::OnDynamicTree => {
+                                let _ = self.tree.remove(proxy.leaf);
+                            }
+                            ProxyStatus::Detached => { }
+                        }
+                    }
+                }
+            }
+        }
+
+        /*
+         * Re-insert outdated nodes one by one and collect interferences at the same time.
+         */
+        for leaf in self.to_update.drain(..) {
+            {
+                let proxy1 = &self.proxies[leaf.data];
+                {
+                    let mut visitor = BoundingVolumeInterferencesCollector::new(
+                        &leaf.bounding_volume,
+                        &mut self.collector);
+
+                    self.tree.visit(&mut visitor);
+                    self.stree.visit(&mut visitor);
+                }
+
+                // Event generation.
+                for proxy_key2 in self.collector.iter() {
+                    let proxy2 = &self.proxies[*proxy_key2];
+
+                    if allow_proximity(&proxy1.data, &proxy2.data) {
+                        let mut trigger = false;
+
+                        let _ = self.pairs.find_or_insert_lazy(
+                            Pair::new(leaf.data, *proxy_key2),
+                            || { trigger = true; Some(()) });
+
+                        if trigger {
+                            handler(&proxy1.data, &proxy2.data, true)
+                        }
+                    }
+                }
+
+                self.collector.clear();
+            }
+
+            let proxy1 = &mut self.proxies[leaf.data];
+            proxy1.leaf = self.tree.insert(leaf);
+        }
+
+        self.purge_some_contact_pairs(allow_proximity, handler);
+        self.update_activation_states();
+    }
+
+    fn deferred_add(&mut self, uid: usize, bv: BV, data: T) {
+        let proxy = DBVTBroadPhaseProxy::new(data);
+        let (proxy_key, value) = self.proxies.insert_or_replace(uid, proxy, false);
+
+        if let Some(proxy) = value {
+            let _ = self.actions.insert(proxy_key, Action::Modify(bv, Some(proxy.data)));
+        }
+        else {
+            let _ = self.actions.insert(proxy_key, Action::Modify(bv, None));
+        }
+    }
+
+    fn deferred_remove(&mut self, uid: usize) {
+        if let Some(proxy_key) = self.proxies.get_fast_key(uid) {
+            let _ = self.actions.insert(proxy_key, Action::Remove(uid));
+            self.purge_all = true;
+        }
+    }
+
+    fn deferred_set_bounding_volume(&mut self, uid: usize, bounding_volume: BV) {
+        if let Some(proxy_key) = self.proxies.get_fast_key(uid) {
+            let proxy = &mut self.proxies[proxy_key];
+
+            match self.actions.entry(proxy_key) {
+                Entry::Occupied(mut entry) => {
+                    match *entry.get_mut() {
+                        Action::Modify(ref mut bv, _) => {
+                            *bv = bounding_volume.loosened(self.margin);
+                        },
+                        Action::Remove(_) => { }
+                    }
+                },
+                Entry::Vacant(entry) => {
+                    let needs_update = match proxy.status() {
+                        ProxyStatus::OnStaticTree  =>
+                            !self.stree[proxy.leaf].bounding_volume.contains(&bounding_volume),
+                        ProxyStatus::OnDynamicTree =>
+                            !self.tree[proxy.leaf].bounding_volume.contains(&bounding_volume),
+                        ProxyStatus::Detached      => true
+                    };
+
+                    if needs_update {
+                        let new_bv = bounding_volume.loosened(self.margin);
+                        let _ = entry.insert(Action::Modify(new_bv, None));
+                    }
+                }
+            }
+        }
+    }
+
+    fn deferred_recompute_all_proximities(&mut self) {
+        for (proxy_key, proxy) in self.proxies.iter() {
+            let bv;
+            match proxy.status() {
+                ProxyStatus::OnStaticTree  => { bv = &self.stree[proxy.leaf].bounding_volume; }
+                ProxyStatus::OnDynamicTree => { bv = &self.tree[proxy.leaf].bounding_volume; }
+                ProxyStatus::Detached      => continue
+            }
+
+            match self.actions.entry(proxy_key) {
+                Entry::Vacant(entry) => {
+                    // FIXME: too bad we have to clone the bounding volume…
+                    let _  = entry.insert(Action::Modify(bv.clone(), None));
+                },
+                Entry::Occupied(_) => { }
+            }
+        }
+    }
+
+    fn interferences_with_bounding_volume<'a>(&'a self, bv: &BV, out: &mut Vec<&'a T>) {
+        let mut collector = Vec::new();
+
+        {
+            let mut visitor = BoundingVolumeInterferencesCollector::new(bv, &mut collector);
+
+            self.tree.visit(&mut visitor);
+            self.stree.visit(&mut visitor);
+        }
+
+        for l in collector.into_iter() {
+            out.push(&self.proxies[l].data)
+        }
+    }
+
+    fn interferences_with_ray<'a>(&'a self, ray: &Ray<P>, out: &mut Vec<&'a T>) {
+        let mut collector = Vec::new();
+
+        {
+            let mut visitor = RayInterferencesCollector::new(ray, &mut collector);
+
+            self.tree.visit(&mut visitor);
+            self.stree.visit(&mut visitor);
+        }
+
+        for l in collector.into_iter() {
+            out.push(&self.proxies[l].data)
+        }
+    }
+
+    fn interferences_with_point<'a>(&'a self, point: &P, out: &mut Vec<&'a T>) {
+        let mut collector = Vec::new();
+
+        {
+            let mut visitor = PointInterferencesCollector::new(point, &mut collector);
+
+            self.tree.visit(&mut visitor);
+            self.stree.visit(&mut visitor);
+        }
+
+        for l in collector.into_iter() {
+            out.push(&self.proxies[l].data)
+        }
+    }
+}

--- a/ncollide_pipeline/broad_phase/mod.rs
+++ b/ncollide_pipeline/broad_phase/mod.rs
@@ -3,12 +3,14 @@
 #[doc(inline)]
 pub use self::broad_phase::BroadPhase;
 pub use self::brute_force_broad_phase::BruteForceBroadPhase;
-pub use self::dbvt_broad_phase::DBVTBroadPhase;
+// pub use self::dbvt_broad_phase::DBVTBroadPhase;
+pub use self::dbvt_broad_phase2::DBVTBroadPhase;
 pub use self::broad_phase_pair_filter::{BroadPhasePairFilter, BroadPhasePairFilters};
 
 #[doc(hidden)]
 pub mod broad_phase;
 mod brute_force_broad_phase;
-mod dbvt_broad_phase;
+// mod dbvt_broad_phase;
 #[doc(hidden)]
 pub mod broad_phase_pair_filter;
+mod dbvt_broad_phase2;

--- a/ncollide_pipeline/events/mod.rs
+++ b/ncollide_pipeline/events/mod.rs
@@ -1,0 +1,54 @@
+use geometry::query::Proximity;
+use world::CollisionObjectHandle;
+
+// FIXME: we want a structure where we can add elements, iterate on them, but not remove them
+// without clearing the whole structure.
+pub struct EventPool<E> {
+    events: Vec<E>
+}
+
+pub type ContactEvents   = EventPool<ContactEvent>;
+pub type ProximityEvents = EventPool<ProximityEvent>;
+
+
+impl<E> EventPool<E> {
+    pub fn new() -> EventPool<E> {
+        EventPool {
+            events: Vec::new()
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+
+    pub fn push(&mut self, event: E) {
+        self.events.push(event);
+    }
+}
+
+#[derive(Copy, Clone, Hash, Debug)]
+pub enum ContactEvent {
+    Started(CollisionObjectHandle, CollisionObjectHandle),
+    Stopped(CollisionObjectHandle, CollisionObjectHandle)
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ProximityEvent {
+    co1:         CollisionObjectHandle,
+    co2:         CollisionObjectHandle,
+    prev_status: Proximity,
+    new_status:  Proximity
+}
+
+impl ProximityEvent {
+    pub fn new(co1:         CollisionObjectHandle,
+               co2:         CollisionObjectHandle,
+               prev_status: Proximity,
+               new_status:  Proximity)
+              -> ProximityEvent {
+        ProximityEvent {
+            co1, co2, prev_status, new_status
+        }
+    }
+}

--- a/ncollide_pipeline/lib.rs
+++ b/ncollide_pipeline/lib.rs
@@ -20,3 +20,4 @@ extern crate ncollide_geometry as geometry;
 pub mod broad_phase;
 pub mod narrow_phase;
 pub mod world;
+pub mod events;

--- a/ncollide_pipeline/narrow_phase/contact_generator/contact_generator.rs
+++ b/ncollide_pipeline/narrow_phase/contact_generator/contact_generator.rs
@@ -1,9 +1,11 @@
+use std::any::Any;
+
 use geometry::shape::Shape;
 use geometry::query::Contact;
 use math::Point;
 
 /// Trait implemented algorithms that compute contact points, normals and penetration depths.
-pub trait ContactGenerator<P: Point, M> {
+pub trait ContactGenerator<P: Point, M>: Any + Send + Sync {
     /// Runs the collision detection on two objects. It is assumed that the same
     /// collision detector (the same structure) is always used with the same
     /// pair of object.
@@ -23,9 +25,9 @@ pub trait ContactGenerator<P: Point, M> {
     fn contacts(&self, &mut Vec<Contact<P>>);
 }
 
-pub type ContactAlgorithm<P, M> = Box<ContactGenerator<P, M> + 'static>;
+pub type ContactAlgorithm<P, M> = Box<ContactGenerator<P, M>>;
 
-pub trait ContactDispatcher<P, M> {
+pub trait ContactDispatcher<P, M>: Any + Send + Sync {
     /// Allocate a collision algorithm corresponding to the given pair of shapes.
     fn get_contact_algorithm(&self, a: &Shape<P, M>, b: &Shape<P, M>) -> Option<ContactAlgorithm<P, M>>;
 }

--- a/ncollide_pipeline/narrow_phase/contact_signal.rs
+++ b/ncollide_pipeline/narrow_phase/contact_signal.rs
@@ -1,9 +1,11 @@
+use std::any::Any;
+
 use world::CollisionObject;
 use narrow_phase::ContactAlgorithm;
 use math::Point;
 
 /// A signal handler for contact detection.
-pub trait ContactHandler<P: Point, M, T> {
+pub trait ContactHandler<P: Point, M, T>: Any + Send + Sync {
     /// Activate an action for when two objects start being in contact.
     fn handle_contact_started(&mut self,
                               co1:      &CollisionObject<P, M, T>,
@@ -16,7 +18,7 @@ pub trait ContactHandler<P: Point, M, T> {
 
 /// Signal for contact start/stop.
 pub struct ContactSignal<P: Point, M, T> {
-    contact_handlers: Vec<(String, Box<ContactHandler<P, M, T> + 'static>)>,
+    contact_handlers: Vec<(String, Box<ContactHandler<P, M, T>>)>,
 }
 
 impl<P: Point, M, T> ContactSignal<P, M, T> {
@@ -30,7 +32,7 @@ impl<P: Point, M, T> ContactSignal<P, M, T> {
     /// Registers an event handler.
     pub fn register_contact_handler(&mut self,
                                     name:     &str,
-                                    callback: Box<ContactHandler<P, M, T> + 'static>) {
+                                    callback: Box<ContactHandler<P, M, T>>) {
         for &mut (ref mut n, ref mut f) in self.contact_handlers.iter_mut() {
             if name == &n[..] {
                 *f = callback;

--- a/ncollide_pipeline/narrow_phase/default_narrow_phase.rs
+++ b/ncollide_pipeline/narrow_phase/default_narrow_phase.rs
@@ -11,17 +11,17 @@ use math::Point;
 // FIXME: move this to the `narrow_phase` module.
 /// Collision detector dispatcher for collision objects.
 pub struct DefaultNarrowPhase<P, M> {
-    contact_dispatcher: Box<ContactDispatcher<P, M> + 'static>,
+    contact_dispatcher: Box<ContactDispatcher<P, M>>,
     contact_generators: HashMap<Pair, ContactAlgorithm<P, M>, PairTWHash>,
 
-    proximity_dispatcher: Box<ProximityDispatcher<P, M> + 'static>,
+    proximity_dispatcher: Box<ProximityDispatcher<P, M>>,
     proximity_detectors:  HashMap<Pair, ProximityAlgorithm<P, M>, PairTWHash>,
 }
 
 impl<P: Point, M: 'static> DefaultNarrowPhase<P, M> {
     /// Creates a new `DefaultNarrowPhase`.
-    pub fn new(contact_dispatcher:   Box<ContactDispatcher<P, M> + 'static>,
-               proximity_dispatcher: Box<ProximityDispatcher<P, M> + 'static>)
+    pub fn new(contact_dispatcher:   Box<ContactDispatcher<P, M>>,
+               proximity_dispatcher: Box<ProximityDispatcher<P, M>>)
                -> DefaultNarrowPhase<P, M> {
         DefaultNarrowPhase {
             contact_dispatcher: contact_dispatcher,

--- a/ncollide_pipeline/narrow_phase/narrow_phase.rs
+++ b/ncollide_pipeline/narrow_phase/narrow_phase.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::slice::Iter;
 use utils::data::hash_map::Entry;
 use utils::data::pair::Pair;
@@ -12,7 +13,7 @@ use math::Point;
 ///
 /// The narrow phase manager is responsible for creating, updating and generating contact pairs
 /// between objects identified by the broad phase.
-pub trait NarrowPhase<P: Point, M, T> {
+pub trait NarrowPhase<P: Point, M, T>: Any + Send + Sync {
     /// Updates this narrow phase.
     fn update(&mut self,
               objects:          &UidRemap<CollisionObject<P, M, T>>,
@@ -44,14 +45,14 @@ pub trait NarrowPhase<P: Point, M, T> {
 /// Iterator through contact pairs.
 pub struct ContactPairs<'a, P: Point + 'a, M: 'a, T: 'a> {
     objects: &'a UidRemap<CollisionObject<P, M, T>>,
-    pairs:   Iter<'a, Entry<Pair, Box<ContactGenerator<P, M> + 'static>>>
+    pairs:   Iter<'a, Entry<Pair, Box<ContactGenerator<P, M>>>>
 }
 
 impl<'a, P: 'a + Point, M: 'a, T: 'a> ContactPairs<'a, P, M, T> {
     #[doc(hidden)]
     #[inline]
     pub fn new(objects: &'a UidRemap<CollisionObject<P, M, T>>,
-               pairs:   Iter<'a, Entry<Pair, Box<ContactGenerator<P, M> + 'static>>>)
+               pairs:   Iter<'a, Entry<Pair, Box<ContactGenerator<P, M>>>>)
                -> ContactPairs<'a, P, M, T> {
         ContactPairs {
             objects: objects,
@@ -141,14 +142,14 @@ impl<'a, P: Point, M, T> Iterator for Contacts<'a, P, M, T> {
 /// Iterator through proximity pairs.
 pub struct ProximityPairs<'a, P: Point + 'a, M: 'a, T: 'a> {
     objects: &'a UidRemap<CollisionObject<P, M, T>>,
-    pairs:   Iter<'a, Entry<Pair, Box<ProximityDetector<P, M> + 'static>>>
+    pairs:   Iter<'a, Entry<Pair, Box<ProximityDetector<P, M>>>>
 }
 
 impl<'a, P: 'a + Point, M: 'a, T: 'a> ProximityPairs<'a, P, M, T> {
     #[doc(hidden)]
     #[inline]
     pub fn new(objects: &'a UidRemap<CollisionObject<P, M, T>>,
-               pairs:   Iter<'a, Entry<Pair, Box<ProximityDetector<P, M> + 'static>>>)
+               pairs:   Iter<'a, Entry<Pair, Box<ProximityDetector<P, M>>>>)
                -> ProximityPairs<'a, P, M, T> {
         ProximityPairs {
             objects: objects,

--- a/ncollide_pipeline/narrow_phase/narrow_phase.rs
+++ b/ncollide_pipeline/narrow_phase/narrow_phase.rs
@@ -4,8 +4,9 @@ use utils::data::hash_map::Entry;
 use utils::data::pair::Pair;
 use utils::data::uid_remap::{UidRemap, FastKey};
 use geometry::query::Contact;
-use narrow_phase::{ContactAlgorithm, ContactSignal, ContactGenerator,
+use narrow_phase::{ContactAlgorithm, ContactGenerator,
                    ProximityAlgorithm, ProximitySignal, ProximityDetector};
+use events::{ContactEvents, ProximityEvents};
 use world::CollisionObject;
 use math::Point;
 
@@ -17,14 +18,14 @@ pub trait NarrowPhase<P: Point, M, T>: Any + Send + Sync {
     /// Updates this narrow phase.
     fn update(&mut self,
               objects:          &UidRemap<CollisionObject<P, M, T>>,
-              contact_signal:   &mut ContactSignal<P, M, T>,
-              proximity_signal: &mut ProximitySignal<P, M, T>,
+              contact_events:   &mut ContactEvents,
+              proximity_events: &mut ProximityEvents,
               timestamp:        usize);
 
     /// Called when the broad phase detects that two objects are, or stop to be, in close proximity.
     fn handle_interaction(&mut self,
-                          contact_signal:   &mut ContactSignal<P, M, T>,
-                          proximity_signal: &mut ProximitySignal<P, M, T>,
+                          contact_signal:   &mut ContactEvents,
+                          proximity_signal: &mut ProximityEvents,
                           objects:          &UidRemap<CollisionObject<P, M, T>>,
                           fk1:              &FastKey,
                           fk2:              &FastKey,

--- a/ncollide_pipeline/narrow_phase/proximity_detector/proximity_detector.rs
+++ b/ncollide_pipeline/narrow_phase/proximity_detector/proximity_detector.rs
@@ -1,9 +1,11 @@
+use std::any::Any;
+
 use geometry::query::Proximity;
 use geometry::shape::Shape;
 use math::Point;
 
 /// Trait implemented by algorithms that determine if two objects are in close proximity.
-pub trait ProximityDetector<P: Point, M> {
+pub trait ProximityDetector<P: Point, M>: Any + Send + Sync {
     /// Runs the proximity detection on two objects. It is assumed that the same proximity detector
     /// (the same structure) is always used with the same pair of object.
     fn update(&mut self,
@@ -19,9 +21,9 @@ pub trait ProximityDetector<P: Point, M> {
     fn proximity(&self) -> Proximity;
 }
 
-pub type ProximityAlgorithm<P, M> = Box<ProximityDetector<P, M> + 'static>;
+pub type ProximityAlgorithm<P, M> = Box<ProximityDetector<P, M>>;
 
-pub trait ProximityDispatcher<P: Point, M> {
+pub trait ProximityDispatcher<P: Point, M>: Any + Send + Sync {
     /// Allocate a collision algorithm corresponding to the given pair of shapes.
     fn get_proximity_algorithm(&self, a: &Shape<P, M>, b: &Shape<P, M>) -> Option<ProximityAlgorithm<P, M>>;
 }

--- a/ncollide_pipeline/narrow_phase/proximity_signal.rs
+++ b/ncollide_pipeline/narrow_phase/proximity_signal.rs
@@ -1,9 +1,11 @@
+use std::any::Any;
+
 use geometry::query::Proximity;
 use world::CollisionObject;
 use math::Point;
 
 /// A signal handler for proximity detection.
-pub trait ProximityHandler<P: Point, M, T> {
+pub trait ProximityHandler<P: Point, M, T>: Any + Send + Sync {
     /// Activate an action for when two objects start or stop to be close to each other.
     fn handle_proximity(&mut self,
                         co1: &CollisionObject<P, M, T>,
@@ -14,7 +16,7 @@ pub trait ProximityHandler<P: Point, M, T> {
 
 /// Signal for proximity start/stop.
 pub struct ProximitySignal<P: Point, M, T> {
-    proximity_handlers: Vec<(String, Box<ProximityHandler<P, M, T> + 'static>)>,
+    proximity_handlers: Vec<(String, Box<ProximityHandler<P, M, T>>)>,
 }
 
 impl<P: Point, M, T> ProximitySignal<P, M, T> {
@@ -28,7 +30,7 @@ impl<P: Point, M, T> ProximitySignal<P, M, T> {
     /// Registers an event handler.
     pub fn register_proximity_handler(&mut self,
                                       name:     &str,
-                                      callback: Box<ProximityHandler<P, M, T> + 'static>) {
+                                      callback: Box<ProximityHandler<P, M, T>>) {
         for &mut (ref mut n, ref mut f) in self.proximity_handlers.iter_mut() {
             if name == &n[..] {
                 *f = callback;

--- a/ncollide_pipeline/tests/collision_world.rs
+++ b/ncollide_pipeline/tests/collision_world.rs
@@ -1,38 +1,31 @@
 extern crate ncollide_pipeline;
-extern crate ncollide_entities;
+extern crate ncollide_geometry;
 extern crate nalgebra;
 
-use ncollide_pipeline::world::{CollisionGroups, CollisionWorld, CollisionWorld2};
-use ncollide_geometry::shape::Ball;
-use ncollide_geometry::inspection::Repr2;
-use nalgebra::{Vec1, Vector2, Isometry2};
-use std::sync::Arc;
-
-type ObjectCollisionWorld = CollisionWorld2<f64, ()>;
-type ShapeRepr = Repr2<f64>;
-
+use ncollide_pipeline::world::{CollisionGroups, CollisionWorld, GeometricQueryType};
+use ncollide_geometry::shape::{Ball, ShapeHandle};
+use nalgebra as na;
 
 #[test]
 fn issue_57_object_remove() {
-	let mut world: ObjectCollisionWorld = CollisionWorld::new(0.1, 0.1, false);
-    let shape = Arc::new(Box::new(Ball::new(1.0)) as Box<ShapeRepr>);
-    world.add(0,
-              Isometry2::new(Vector2::new(1.0, 0.0), Vec1::new(0.0)),
-              shape.clone(),
-              CollisionGroups::new(),
-              ());
-   world.add(1,
-              Isometry2::new(Vector2::new(1.0, 1.0), Vec1::new(0.0)),
-              shape.clone(),
-              CollisionGroups::new(),
-              ());
-	world.add(2,
-              Isometry2::new(Vector2::new(1.0, 2.0), Vec1::new(0.0)),
-              shape.clone(),
-              CollisionGroups::new(),
-              ());
-    world.update();
-    world.remove(0);
-    world.update();
-    world.update();
+    let mut world: CollisionWorld<_,_,_> = CollisionWorld::new(0.1, false);
+    let shape = Ball::new(1.0);
+
+    world.deferred_add(
+        0,
+        na::Isometry2::new(na::Vector2::new(1.0, 0.0), 0.0),
+        ShapeHandle::new(shape.clone()),
+        CollisionGroups::new(),
+        GeometricQueryType::Contacts(0.0),
+        ());
+    world.deferred_add(
+        1,
+        na::Isometry2::new(na::Vector2::new(1.0, 0.0), 0.0),
+        ShapeHandle::new(shape.clone()),
+        CollisionGroups::new(),
+        GeometricQueryType::Contacts(0.0),
+        ());
+    world.perform_additions_removals_and_broad_phase();
+    world.deferred_remove(0);
+    world.perform_additions_removals_and_broad_phase();
 }

--- a/ncollide_pipeline/world/collision_object.rs
+++ b/ncollide_pipeline/world/collision_object.rs
@@ -4,6 +4,10 @@ use math::Point;
 use geometry::shape::ShapeHandle;
 use world::CollisionGroups;
 
+// FIXME: use this or a FastKey?
+pub type CollisionObjectHandle = usize;
+
+
 /// The kind of query a CollisionObject may be involved on.
 ///
 /// The following queries are executed for a given pair of `GeometricQueryType` associated with two

--- a/ncollide_pipeline/world/collision_world.rs
+++ b/ncollide_pipeline/world/collision_world.rs
@@ -13,9 +13,9 @@ use broad_phase::{BroadPhase, DBVTBroadPhase, BroadPhasePairFilter, BroadPhasePa
 use world::{CollisionObject, GeometricQueryType, CollisionGroups, CollisionGroupsPairFilter};
 
 /// Type of the narrow phase trait-object used by the collision world.
-pub type NarrowPhaseObject<P, M, T> = Box<NarrowPhase<P, M, T> + 'static>;
+pub type NarrowPhaseObject<P, M, T> = Box<NarrowPhase<P, M, T>>;
 /// Type of the broad phase trait-object used by the collision world.
-pub type BroadPhaseObject<P> = Box<BroadPhase<P, AABB<P>, FastKey> + 'static>;
+pub type BroadPhaseObject<P> = Box<BroadPhase<P, AABB<P>, FastKey>>;
 
 /// A world that handles collision objects.
 pub struct CollisionWorld<P: Point, M, T> {
@@ -115,7 +115,7 @@ impl<P: Point, M: Isometry<P>, T> CollisionWorld<P, M, T> {
     /// a non-trivial overhead during the next update as it will force re-detection of all
     /// collision pairs.
     pub fn register_broad_phase_pair_filter<F>(&mut self, name: &str, filter: F)
-        where F: BroadPhasePairFilter<P, M, T> + 'static {
+        where F: BroadPhasePairFilter<P, M, T> {
         self.pair_filters.register_collision_filter(name, Box::new(filter));
         self.broad_phase.deferred_recompute_all_proximities();
     }
@@ -129,7 +129,7 @@ impl<P: Point, M: Isometry<P>, T> CollisionWorld<P, M, T> {
 
     /// Registers a handler for contact start/stop events.
     pub fn register_contact_handler<H>(&mut self, name: &str, handler: H)
-        where H: ContactHandler<P, M, T> + 'static {
+        where H: ContactHandler<P, M, T> {
         self.contact_signal.register_contact_handler(name, Box::new(handler));
     }
 
@@ -140,7 +140,7 @@ impl<P: Point, M: Isometry<P>, T> CollisionWorld<P, M, T> {
 
     /// Registers a handler for proximity status change events.
     pub fn register_proximity_handler<H>(&mut self, name: &str, handler: H)
-        where H: ProximityHandler<P, M, T> + 'static {
+        where H: ProximityHandler<P, M, T> {
         self.proximity_signal.register_proximity_handler(name, Box::new(handler));
     }
 

--- a/ncollide_pipeline/world/mod.rs
+++ b/ncollide_pipeline/world/mod.rs
@@ -1,6 +1,6 @@
 //! High level API to detect collisions in large, complex scenes.
 
-pub use self::collision_object::{GeometricQueryType, CollisionObject};
+pub use self::collision_object::{GeometricQueryType, CollisionObject, CollisionObjectHandle};
 pub use self::collision_groups::{CollisionGroups, CollisionGroupsPairFilter};
 pub use self::collision_world::{BroadPhaseObject, NarrowPhaseObject, CollisionWorld};
 

--- a/ncollide_utils/data/hash.rs
+++ b/ncollide_utils/data/hash.rs
@@ -11,12 +11,12 @@ pub trait HashFun<K> {
 
 /// Hash function for pairs of `usize`, using the Tomas Wang hash.
 #[derive(Clone, RustcEncodable, RustcDecodable)]
-pub struct UintPairTWHash { unused: usize }
+pub struct UintPairTWHash;
 
 impl UintPairTWHash {
     /// Creates a new UintPairTWHash.
     pub fn new() -> UintPairTWHash {
-        UintPairTWHash { unused: 0 }
+        UintPairTWHash
     }
 }
 
@@ -36,12 +36,12 @@ impl HashFun<(usize, usize)> for UintPairTWHash {
 
 /// Hash function for `usize`.
 #[derive(Clone, RustcEncodable, RustcDecodable)]
-pub struct UintTWHash { unused: usize } // FIXME: ICE if the struct is zero-sized
+pub struct UintTWHash;
 
 impl UintTWHash {
     /// Creates a new UintTWHash.
     pub fn new() -> UintTWHash {
-        UintTWHash { unused: 0 }
+        UintTWHash
     }
 }
 

--- a/ncollide_utils/data/hash_map.rs
+++ b/ncollide_utils/data/hash_map.rs
@@ -333,14 +333,6 @@ impl<K: PartialEq, V, H: HashFun<K>> HashMap<K, V, H> {
         self.get_and_remove(key).is_some()
     }
 
-    // pub fn swap(&mut self, _: K, _: V) -> Option<V> {
-    //     panic!("Not yet implemented.")
-    // }
-
-    // pub fn pop(&mut self, _: &K) -> Option<V> {
-    //     panic!("Not yet implemented.")
-    // }
-
     /// Gets a mutable reference to an element of the hashmap.
     pub fn find_mut<'a>(&'a mut self, key: &K) -> Option<&'a mut V> {
         let entry = self.find_entry_id(key);

--- a/ncollide_utils/data/mod.rs
+++ b/ncollide_utils/data/mod.rs
@@ -1,5 +1,7 @@
 //! Data structure utilities.
 
+pub use self::sparse_vec::SparseVec;
+
 pub mod pair;
 pub mod hash;
 pub mod hash_map;
@@ -8,3 +10,4 @@ pub mod vec_slice;
 pub mod ref_with_cost;
 pub mod uid_remap;
 pub mod vec_map;
+mod sparse_vec;

--- a/ncollide_utils/data/owned_allocation_cache.rs
+++ b/ncollide_utils/data/owned_allocation_cache.rs
@@ -1,3 +1,4 @@
+// XXX Remove this when the old DBVT is removed.
 //! Allocation cache for owned objects.
 
 // FIXME: add a limit to the cache?

--- a/ncollide_utils/data/sparse_vec.rs
+++ b/ncollide_utils/data/sparse_vec.rs
@@ -1,0 +1,71 @@
+use std::ops::{Index, IndexMut};
+use std::mem;
+
+/// A sparse vector data structure.
+pub struct SparseVec<T> {
+    data: Vec<Option<T>>,
+    free: Vec<usize>
+}
+
+impl<T> Index<usize> for SparseVec<T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, i: usize) -> &T {
+        self.data[i].as_ref().expect("Element not found.")
+    }
+}
+
+impl<T> IndexMut<usize> for SparseVec<T> {
+    #[inline]
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        self.data[i].as_mut().expect("Element not found.")
+    }
+}
+
+impl<T> SparseVec<T> {
+    /// Creates a new sparse vector data structure.
+    pub fn new() -> SparseVec<T> {
+        SparseVec {
+            data: Vec::new(),
+            free: Vec::new()
+        }
+    }
+
+    /// Adds an element to this vector and returns its index.
+    #[inline]
+    pub fn push(&mut self, data: T) -> usize {
+        if let Some(i) = self.free.pop() {
+            self.data[i] = Some(data);
+            i
+        }
+        else {
+            self.data.push(Some(data));
+            self.data.len() - 1
+        }
+    }
+
+    /// Attempts to remove an element from this vector and returns it.
+    #[inline]
+    pub fn remove(&mut self, id: usize) -> Option<T> {
+        if id < self.data.len() {
+            mem::replace(&mut self.data[id], None)
+        }
+        else {
+            None
+        }
+    }
+
+    /// Removes all elements from this vector.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.free.clear();
+    }
+
+    /// Indicates whether this sparse vector is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.len() - self.free.len() == 0
+    }
+}

--- a/ncollide_utils/data/uid_remap.rs
+++ b/ncollide_utils/data/uid_remap.rs
@@ -367,6 +367,22 @@ impl<O> IndexMut<FastKey> for UidRemap<O> {
     }
 }
 
+impl<O> Index<usize> for UidRemap<O> {
+    type Output = O;
+
+    #[inline]
+    fn index(&self, key: usize) -> &O {
+        self.get(key).expect("key not present")
+    }
+}
+
+impl<O> IndexMut<usize> for UidRemap<O> {
+    #[inline]
+    fn index_mut(&mut self, key: usize) -> &mut O {
+        self.get_mut(key).expect("key not present")
+    }
+}
+
 /// A fast hasher for FastKey objects.
 pub struct FastKeyTWHash;
 


### PR DESCRIPTION
This commit contains:
* impl index<usize> for uid_remap
* update ncollide_pipeline/tests/collision_world.rs test
* modification of dbvt2:
  * had a rem_proxies field on dbvt2
  * rem_proxies contains proxies removed on the update so they can
    be send to the handle when removing contact pair
  * rem_proxies is cleaned at each update

I don't know if we really need to send the end of contact when removing
a body.
If we don't need to then we can just remove this rem_proxies and only
keep the contact removal when proxy doesn't exist anymore