### PR TITLE
Add failing test for raycasting accuracy on `ConvexPolygon`

### DIFF
--- a/build/ncollide2d/tests/geometry/ray_cast.rs
+++ b/build/ncollide2d/tests/geometry/ray_cast.rs
@@ -1,6 +1,6 @@
 use na::{self, Isometry2, Point2, Vector2};
 use ncollide2d::query::{Ray, RayCast};
-use ncollide2d::shape::Segment;
+use ncollide2d::shape::{ConvexPolygon, Segment, Shape};
 
 #[test]
 fn issue_178_parallel_raycast() {
@@ -87,4 +87,55 @@ fn perpendicular_raycast_starting_bellow_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, -11.0), Vector2::new(1.0, 0.0));
     assert!(!segment.intersects_ray(&na::one(), &ray));
+}
+
+///    Ray Target
+///    +
+/// 3  |     Ray moved up each iteration
+/// |  v     ^
+/// 2  *--+  |
+/// |  |  |  +
+/// 1  +--+  *<----+Ray origin
+/// |
+/// 0--1--2--3
+///
+/// Tests the accuracy of raycaster collision detection against a `ConvexPolygon`.
+#[test]
+fn convexpoly_raycast_fuzz() {
+    let vertices: Vec<Point2<f64>> = vec![[1, 1], [1, 2], [2, 2], [2, 1]]
+        .into_iter()
+        .map(|[x, y]| Point2::new(x as f64, y as f64))
+        .collect();
+
+    let square = ConvexPolygon::try_new(vertices).unwrap();
+    let raycaster = square.as_ray_cast().unwrap();
+
+    let test_raycast = |ray_origin: Point2<f64>, ray_look_at: Point2<f64>| -> Option<f64> {
+        let mut ray_angle: Vector2<f64> = ray_look_at - ray_origin;
+        let ray_angle_magnitude =
+            ((ray_angle.x * ray_angle.x) + (ray_angle.y + ray_angle.y)).sqrt();
+        ray_angle /= ray_angle_magnitude;
+
+        raycaster.toi_with_ray(
+            &Isometry2::identity(),
+            &Ray::new(ray_origin, ray_angle),
+            true,
+        )
+    };
+
+    for i in 0..10_000 {
+        let ray_origin = Point2::new(3., 1. + (i as f64 * 0.0001));
+        let ray_look_at = Point2::new(0., 2.);
+        let collision = test_raycast(ray_origin, ray_look_at);
+
+        match collision {
+            Some(distance) if distance >= 1.0 && distance < (2.0f64).sqrt() => (),
+            Some(distance) if distance >= 2.0 => panic!(
+                "Collided with back face instead of front face. Distance: {}",
+                distance
+            ),
+            Some(distance) => panic!("Invalid collision distance: {}", distance),
+            None => panic!("Failed to collide with any face"),
+        }
+    }
 }

--- a/build/ncollide2d/tests/geometry/ray_cast.rs
+++ b/build/ncollide2d/tests/geometry/ray_cast.rs
@@ -102,7 +102,7 @@ fn perpendicular_raycast_starting_bellow_segment() {
 /// Tests the accuracy of raycaster collision detection against a `ConvexPolygon`.
 #[test]
 fn convexpoly_raycast_fuzz() {
-    let vertices: Vec<Point2<f64>> = vec![[1, 1], [1, 2], [2, 2], [2, 1]]
+    let vertices: Vec<Point2<f64>> = vec![[2, 1], [2, 2], [1, 2], [1, 1]]
         .into_iter()
         .map(|[x, y]| Point2::new(x as f64, y as f64))
         .collect();
@@ -111,14 +111,11 @@ fn convexpoly_raycast_fuzz() {
     let raycaster = square.as_ray_cast().unwrap();
 
     let test_raycast = |ray_origin: Point2<f64>, ray_look_at: Point2<f64>| -> Option<f64> {
-        let mut ray_angle: Vector2<f64> = ray_look_at - ray_origin;
-        let ray_angle_magnitude =
-            ((ray_angle.x * ray_angle.x) + (ray_angle.y + ray_angle.y)).sqrt();
-        ray_angle /= ray_angle_magnitude;
+        let ray_angle = ray_look_at - ray_origin;
 
         raycaster.toi_with_ray(
             &Isometry2::identity(),
-            &Ray::new(ray_origin, ray_angle),
+            &Ray::new(ray_origin, ray_angle.normalize()),
             true,
         )
     };


### PR DESCRIPTION
 * Creates a square `ConvexPolygon` and attempts to find collisions between it and a point behind it, adjusting the origin of the ray each time.