### PR TITLE
Add convenience methods for creating CollisionGroups

### DIFF
--- a/build/ncollide3d/examples/collision_groups.rs
+++ b/build/ncollide3d/examples/collision_groups.rs
@@ -3,19 +3,16 @@ extern crate ncollide3d;
 use ncollide3d::world::CollisionGroups;
 
 fn main() {
-    let mut a = CollisionGroups::new();
-    let mut b = CollisionGroups::new();
-    let mut c = CollisionGroups::new();
-
-    a.set_membership(&[1, 3, 6]);
-    a.set_whitelist(&[6, 7]);
-    a.set_blacklist(&[1]);
-
-    b.set_membership(&[1, 3, 7]);
-    b.set_whitelist(&[3, 7]);
-
-    c.set_membership(&[6, 9]);
-    c.set_whitelist(&[3, 7]);
+    let a = CollisionGroups::new()
+        .with_membership(&[1, 3, 6])
+        .with_whitelist(&[6, 7])
+        .with_blacklist(&[1]);
+    let b = CollisionGroups::new()
+        .with_membership(&[1, 3, 7])
+        .with_whitelist(&[3, 7]);
+    let c = CollisionGroups::new()
+        .with_membership(&[6, 9])
+        .with_whitelist(&[3, 7]);
 
     assert!(!a.can_interact_with_groups(&b));
     assert!(!b.can_interact_with_groups(&c));

--- a/ncollide_testbed2d/examples/bouncing_ball2d.rs
+++ b/ncollide_testbed2d/examples/bouncing_ball2d.rs
@@ -128,14 +128,13 @@ fn main() {
     let ball_pos = Isometry2::new(Vector2::new(5.0, 5.0), na::zero());
 
     // The ball is part of group 1 and can interact with everything.
-    let mut ball_groups = CollisionGroups::new();
-    ball_groups.set_membership(&[1]);
+    let ball_groups = CollisionGroups::new().with_membership(&[1]);
 
     // All the other objects are part of the group 2 and interact only with the ball (but not with
     // each other).
-    let mut others_groups = CollisionGroups::new();
-    others_groups.set_membership(&[2]);
-    others_groups.set_whitelist(&[1]);
+    let others_groups = CollisionGroups::new()
+        .with_membership(&[2])
+        .with_whitelist(&[1]);
 
     let plane_data = CollisionObjectData::new("ground", None);
     let rect_data_purple = CollisionObjectData::new("purple", None);

--- a/ncollide_testbed3d/examples/bouncing_ball3d.rs
+++ b/ncollide_testbed3d/examples/bouncing_ball3d.rs
@@ -135,14 +135,13 @@ fn main() {
     let ball_pos = Isometry3::new(Vector3::new(5.0, 5.0, 5.0), na::zero());
 
     // The ball is part of group 1 and can interact with everything.
-    let mut ball_groups = CollisionGroups::new();
-    ball_groups.set_membership(&[1]);
+    let ball_groups = CollisionGroups::new().with_membership(&[1]);
 
     // All the other objects are part of the group 2 and interact only with the ball (but not with
     // each other).
-    let mut others_groups = CollisionGroups::new();
-    others_groups.set_membership(&[2]);
-    others_groups.set_whitelist(&[1]);
+    let others_groups = CollisionGroups::new()
+        .with_membership(&[2])
+        .with_whitelist(&[1]);
 
     let plane_data = CollisionObjectData::new("ground", None);
     let rect_data_purple = CollisionObjectData::new("purple", None);

--- a/src/pipeline/world/collision_groups.rs
+++ b/src/pipeline/world/collision_groups.rs
@@ -191,7 +191,8 @@ impl CollisionGroups {
     #[inline]
     pub fn can_interact_with_groups(&self, other: &CollisionGroups) -> bool {
         // FIXME: is there a more bitwise-y way of doing this?
-        self.membership & other.blacklist == 0 && other.membership & self.blacklist == 0
+        self.membership & other.blacklist == 0
+            && other.membership & self.blacklist == 0
             && self.membership & other.whitelist != 0
             && other.membership & self.whitelist != 0
     }
@@ -215,11 +216,7 @@ impl CollisionGroupsPairFilter {
 }
 
 impl<N: Real, T> BroadPhasePairFilter<N, T> for CollisionGroupsPairFilter {
-    fn is_pair_valid(
-        &self,
-        co1: &CollisionObject<N, T>,
-        co2: &CollisionObject<N, T>,
-    ) -> bool {
+    fn is_pair_valid(&self, co1: &CollisionObject<N, T>, co2: &CollisionObject<N, T>) -> bool {
         if co1.handle() == co2.handle() {
             co1.collision_groups().can_interact_with_self()
         } else {

--- a/src/pipeline/world/collision_groups.rs
+++ b/src/pipeline/world/collision_groups.rs
@@ -57,6 +57,78 @@ impl CollisionGroups {
         }
     }
 
+    /// Returns a copy of this object, updated with a new set of membership groups.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// const GROUP_A: usize = 0;
+    /// const GROUP_B: usize = 29;
+    /// const groups = CollisionGroups::new().with_membership(&[GROUP_A, GROUP_B]);
+    /// assert!(groups.is_member_of(GROUP_A);
+    /// assert!(groups.is_member_of(GROUP_B);
+    /// ```
+    #[inline]
+    pub fn with_membership(self, groups: &[usize]) -> CollisionGroups {
+        let membership: u32 = groups
+            .iter()
+            .fold(NO_GROUP, |acc, &group| acc | (1 << group)) as u32;
+        assert!(membership < (1 << 30));
+        CollisionGroups {
+            membership,
+            whitelist: self.whitelist,
+            blacklist: self.blacklist,
+        }
+    }
+
+    /// Returns a copy of this object, updated with a new set of whitelisted groups.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// const GROUP_A: usize = 0;
+    /// const GROUP_B: usize = 29;
+    /// const group_a = CollisionGroups::new().with_whitelist(&[GROUP_B]);
+    /// assert!(!group_a.is_group_whitelisted(GROUP_A));
+    /// assert!(group_a.is_group_whitelisted(GROUP_B));
+    /// ```
+    #[inline]
+    pub fn with_whitelist(self, groups: &[usize]) -> CollisionGroups {
+        let whitelist: u32 = groups
+            .iter()
+            .fold(NO_GROUP, |acc, &group| acc | (1 << group)) as u32;
+        assert!(whitelist < (1 << 30));
+        CollisionGroups {
+            membership: self.membership,
+            whitelist: whitelist,
+            blacklist: self.blacklist,
+        }
+    }
+
+    /// Returns a copy of this object, updated with a new set of blacklisted groups.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// const GROUP_A: usize = 0;
+    /// const GROUP_B: usize = 29;
+    /// const group_a = CollisionGroups::new().with_blacklist(&[GROUP_B]);
+    /// assert!(!group_a.is_group_blacklisted(GROUP_A));
+    /// assert!(group_a.is_group_blacklisted(GROUP_B));
+    /// ```
+    #[inline]
+    pub fn with_blacklist(self, groups: &[usize]) -> CollisionGroups {
+        let blacklist: u32 = groups
+            .iter()
+            .fold(NO_GROUP, |acc, &group| acc | (1 << group)) as u32;
+        assert!(blacklist < (1 << 30));
+        CollisionGroups {
+            membership: self.membership,
+            whitelist: self.whitelist,
+            blacklist,
+        }
+    }
+
     /// The maximum allowed group identifier.
     #[inline]
     pub fn max_group_id() -> usize {


### PR DESCRIPTION
Provides builder-pattern style APIs to CollisionGroups --- a nice alternative  for many use-cases.