### PR TITLE
Implement a special-cases of ray-cast on segment.

### DIFF
--- a/src/query/ray_internal/ray.rs
+++ b/src/query/ray_internal/ray.rs
@@ -57,6 +57,8 @@ impl<N: Real> Ray<N> {
 }
 
 /// Structure containing the result of a successful ray cast.
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RayIntersection<N: Real> {
     /// The time of impact of the ray with the object.  The exact contact point can be computed
     /// with: `ray.point_at(toi)` or equivalently `origin + dir * toi` where `origin` is the origin of the ray;

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -349,6 +349,17 @@ impl<N: Real> Polyline<N> {
         }
     }
 
+    /// Returns `true` if the given feature is a FeatureId::Face and
+    /// identifies a backface of this polyline.
+    #[inline]
+    pub fn is_backface(&self, feature: FeatureId) -> bool {
+        if let FeatureId::Face(i) = feature {
+            i >= self.edges.len()
+        } else {
+            false
+        }
+    }
+
     /// Tests that the given `dir` is on the polar of the tangent cone of the `i`th vertex
     /// of this polyline.
     pub fn vertex_tangent_cone_polar_contains_dir(

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -407,6 +407,17 @@ impl<N: Real> TriMesh<N> {
         Triangle::new(self.points[idx.x], self.points[idx.y], self.points[idx.z])
     }
 
+    /// Returns `true` if the given feature is a FeatureId::Face and
+    /// identifies a backface of this trimesh.
+    #[inline]
+    pub fn is_backface(&self, feature: FeatureId) -> bool {
+        if let FeatureId::Face(i) = feature {
+            i >= self.faces.len()
+        } else {
+            false
+        }
+    }
+
     /// The optimization structure used by this triangle mesh.
     #[inline]
     pub fn bvt(&self) -> &BVT<usize, AABB<N>> {


### PR DESCRIPTION
This also fixes the FeatureId returned when casting a ray on a segment or a polyline.