### PR TITLE
 Allow CollisionWorld's NarrowPhase to be replaced 

### DIFF
--- a/src/pipeline/narrow_phase/contact_generator/contact_manifold_generator.rs
+++ b/src/pipeline/narrow_phase/contact_generator/contact_manifold_generator.rs
@@ -6,11 +6,17 @@ use crate::query::ContactPreprocessor;
 use std::any::Any;
 use crate::utils::IdAllocator;
 
-/// Trait implemented algorithms that compute contact points, normals and penetration depths.
+/// An algorithm to compute contact points, normals and penetration depths between two specific
+/// objects.
 pub trait ContactManifoldGenerator<N: Real>: Any + Send + Sync {
     /// Runs the collision detection on two objects. It is assumed that the same
     /// collision detector (the same structure) is always used with the same
-    /// pair of object.
+    /// pair of objects.
+    ///
+    /// Returns `false` if persisting this algorithm for re-use is unlikely to improve performance,
+    /// e.g. due to the objects being distant. Note that if the `ContactManifoldGenerator` would
+    /// likely be immediately reconstructed in the next time-step, dropping it is sub-optimal
+    /// regardless.
     fn generate_contacts(
         &mut self,
         dispatcher: &ContactDispatcher<N>,
@@ -34,6 +40,6 @@ pub trait ContactManifoldGenerator<N: Real>: Any + Send + Sync {
 pub type ContactAlgorithm<N> = Box<ContactManifoldGenerator<N>>;
 
 pub trait ContactDispatcher<N>: Any + Send + Sync {
-    /// Allocate a collision algorithm corresponding to the given pair of shapes.
+    /// Allocate a collision algorithm corresponding to a pair of objects with the given shapes.
     fn get_contact_algorithm(&self, a: &Shape<N>, b: &Shape<N>) -> Option<ContactAlgorithm<N>>;
 }

--- a/src/pipeline/world/collision_world.rs
+++ b/src/pipeline/world/collision_world.rs
@@ -8,7 +8,7 @@ use crate::pipeline::broad_phase::{
 use crate::pipeline::events::{ContactEvent, ContactEvents, ProximityEvents};
 use crate::pipeline::narrow_phase::{
     DefaultContactDispatcher, NarrowPhase, DefaultProximityDispatcher,
-    InteractionGraphIndex, Interaction, ContactAlgorithm, ProximityAlgorithm
+    InteractionGraphIndex, Interaction, ContactAlgorithm, ProximityAlgorithm,
 };
 use crate::pipeline::world::{
     CollisionGroups, CollisionGroupsPairFilter, CollisionObject, CollisionObjectHandle,
@@ -353,6 +353,12 @@ impl<N: Real, T> CollisionWorld<N, T> {
             objects: &self.objects,
             handles: handles.into_iter(),
         }
+    }
+
+    /// Customize the selection of narrowphase collision detection algorithms
+    pub fn set_narrow_phase(&mut self, narrow_phase: NarrowPhase<N>) {
+        self.narrow_phase = narrow_phase;
+        self.broad_phase.deferred_recompute_all_proximities();
     }
 
     /*


### PR DESCRIPTION
This allows a custom `ContactDispatcher` to be installed, making user-supplied `Shape` impls usable.