### PR TITLE
Allow updating collider collision rules.

### DIFF
--- a/src/pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/src/pipeline/broad_phase/dbvt_broad_phase.rs
@@ -132,6 +132,9 @@ impl<N, BV, T> DBVTBroadPhase<N, BV, T>
                             handler.interference_stopped(&proxy1.data, &proxy2.data);
                             retain = false;
                         }
+                    } else {
+                        handler.interference_stopped(&proxy1.data, &proxy2.data);
+                        retain = false;
                     }
                 }
             }


### PR DESCRIPTION
Previously contacts would not be removed (and would seem to persist forever) if collision groups or filters were modified to disallow the contact.

This (rustsim/nphysics#55) indicates that this should take significantly more work, but it seems that all the logic was already there and the check to remove contacts was incorrect.

Should fix rustsim/nphysics#55 and fix #164.