### PR TITLE
Improve triangle AABB performance

### DIFF
--- a/src/bounding_volume/aabb_support_map.rs
+++ b/src/bounding_volume/aabb_support_map.rs
@@ -1,10 +1,10 @@
 use crate::bounding_volume;
 use crate::bounding_volume::{HasBoundingVolume, AABB};
 use crate::math::Isometry;
-use na::RealField;
-use crate::shape::{Segment, Capsule};
+use crate::shape::{Capsule, Segment};
 #[cfg(feature = "dim3")]
-use crate::shape::{Cone, Cylinder, Triangle};
+use crate::shape::{Cone, Cylinder};
+use na::RealField;
 
 #[cfg(feature = "dim3")]
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cone<N> {
@@ -25,15 +25,6 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cylinder<N> {
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Capsule<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        bounding_volume::support_map_aabb(m, self)
-    }
-}
-
-#[cfg(feature = "dim3")]
-impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
-    #[inline]
-    fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        // FIXME: optimize that
         bounding_volume::support_map_aabb(m, self)
     }
 }

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -1,13 +1,51 @@
-use crate::bounding_volume::{HasBoundingVolume, AABB};
-use crate::bounding_volume;
-use crate::shape::Triangle;
-use crate::math::Matrix;
-use crate::math::{Point, Scalar, Vector};
+use crate::{
+    bounding_volume::{HasBoundingVolume, AABB},
+    math::{Isometry, Point, DIM},
+    shape::Triangle,
+};
+use na::RealField;
 
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        // FIXME: optimize that
-        bounding_volume::implicit_shape_aabb(m, self)
+        let a = m.transform_point(self.a()).coords;
+        let b = m.transform_point(self.b()).coords;
+        let c = m.transform_point(self.c()).coords;
+
+        let mut min = unsafe { Point::new_uninitialized() };
+        let mut max = unsafe { Point::new_uninitialized() };
+
+        for d in 0..DIM {
+            min.coords[d] = a[d].min(b[d]).min(c[d]);
+            max.coords[d] = a[d].max(b[d]).max(c[d]);
+        }
+
+        AABB::new(min, max)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        bounding_volume::support_map_aabb,
+        math::{Isometry, Point, Translation},
+        shape::{Shape, Triangle},
+    };
+    use na::{RealField, UnitQuaternion};
+
+    #[test]
+    fn triangle_aabb_matches_support_map_aabb() {
+        let t = Triangle::new(
+            Point::new(0.3, -0.1, 0.2),
+            Point::new(-0.7, 1.0, 0.0),
+            Point::new(-0.7, 1.5, 0.0),
+        );
+
+        let m = Isometry::from_parts(
+            Translation::new(-0.2, 5.0, 0.2),
+            UnitQuaternion::from_euler_angles(0.0, f32::frac_pi_2(), 0.0),
+        );
+
+        assert_eq!(t.aabb(&m), support_map_aabb(&m, &t));
     }
 }

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -26,13 +26,15 @@ mod aabb_convex;
 #[cfg(feature = "dim2")]
 mod aabb_convex_polygon;
 mod aabb_cuboid;
+mod aabb_heightfield;
 mod aabb_plane;
 mod aabb_polyline;
 mod aabb_shape;
 mod aabb_support_map;
 #[cfg(feature = "dim3")]
+mod aabb_triangle;
+#[cfg(feature = "dim3")]
 mod aabb_trimesh;
-mod aabb_heightfield;
 mod aabb_utils;
 
 #[doc(hidden)]
@@ -49,6 +51,7 @@ mod bounding_sphere_convex_polygon;
 mod bounding_sphere_cuboid;
 #[cfg(feature = "dim3")]
 mod bounding_sphere_cylinder;
+mod bounding_sphere_heightfield;
 mod bounding_sphere_plane;
 mod bounding_sphere_polyline;
 mod bounding_sphere_segment;
@@ -57,7 +60,6 @@ mod bounding_sphere_shape;
 mod bounding_sphere_triangle;
 #[cfg(feature = "dim3")]
 mod bounding_sphere_trimesh;
-mod bounding_sphere_heightfield;
 mod bounding_sphere_utils;
 
 pub(crate) mod circular_cone;


### PR DESCRIPTION
A relatively long time inside `TriMesh::new` is spent computing AABBs for triangles in the mesh. Solves the problem by rolling a custom AABB function for triangles, which is around three times as fast as using the generic support map implementation.

This could be further improved in the future by providing an AABB function which doesn't take an isometry parameter (as `TriMesh::new` just passes in `Isometry::identity()` anyway), but it would require some API changes that I wasn't sure how to best approach.