### PR TITLE
Provide bounding volume methods without an isometry parameter

### DIFF
--- a/src/bounding_volume/aabb.rs
+++ b/src/bounding_volume/aabb.rs
@@ -9,12 +9,26 @@ use na::{self, RealField};
 /// Computes the axis-aligned bounding box of a shape `g` transformed by `m`.
 ///
 /// Same as `g.aabb(m)`.
+#[inline]
 pub fn aabb<N, G: ?Sized>(g: &G, m: &Isometry<N>) -> AABB<N>
 where
     N: RealField,
     G: HasBoundingVolume<N, AABB<N>>,
 {
     g.bounding_volume(m)
+}
+
+// Seems useful to help type inference. See issue #84.
+/// Computes the axis-aligned bounding box of a shape `g`.
+///
+/// Same as `g.local_aabb(m)`.
+#[inline]
+pub fn local_aabb<N, G: ?Sized>(g: &G) -> AABB<N>
+where
+    N: RealField,
+    G: HasBoundingVolume<N, AABB<N>>,
+{
+    g.local_bounding_volume()
 }
 
 /// An Axis Aligned Bounding Box.

--- a/src/bounding_volume/aabb_ball.rs
+++ b/src/bounding_volume/aabb_ball.rs
@@ -4,13 +4,21 @@ use crate::math::{Isometry, Point, Vector};
 use na::RealField;
 use crate::shape::Ball;
 
-/// Computes the Axis-Aligned Bounding Box of a ball.
+/// Computes the Axis-Aligned Bounding Box of a ball transformed by `center`.
 #[inline]
 pub fn ball_aabb<N: RealField>(center: &Point<N>, radius: N) -> AABB<N> {
     AABB::new(
         *center + Vector::repeat(-radius),
         *center + Vector::repeat(radius),
     )
+}
+
+/// Computes the Axis-Aligned Bounding Box of a ball.
+#[inline]
+pub fn local_ball_aabb<N: RealField>(radius: N) -> AABB<N> {
+    let half_extents = Point::from(Vector::repeat(radius));
+
+    AABB::new(-half_extents, half_extents)
 }
 
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Ball<N> {
@@ -20,5 +28,10 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Ball<N> {
             &Point::from(m.translation.to_vector()),
             self.radius(),
         )
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        local_ball_aabb(self.radius())
     }
 }

--- a/src/bounding_volume/aabb_compound.rs
+++ b/src/bounding_volume/aabb_compound.rs
@@ -6,7 +6,11 @@ use crate::shape::Compound;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Compound<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        let bv = self.aabb();
-        bv.transform_by(m)
+        self.aabb().transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        self.aabb().clone()
     }
 }

--- a/src/bounding_volume/aabb_convex.rs
+++ b/src/bounding_volume/aabb_convex.rs
@@ -9,4 +9,9 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for ConvexHull<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         aabb_utils::point_cloud_aabb(m, self.points())
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        aabb_utils::local_point_cloud_aabb(self.points())
+    }
 }

--- a/src/bounding_volume/aabb_convex_polygon.rs
+++ b/src/bounding_volume/aabb_convex_polygon.rs
@@ -9,4 +9,9 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for ConvexPolygon<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         aabb_utils::point_cloud_aabb(m, self.points())
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        aabb_utils::local_point_cloud_aabb(self.points())
+    }
 }

--- a/src/bounding_volume/aabb_cuboid.rs
+++ b/src/bounding_volume/aabb_cuboid.rs
@@ -13,4 +13,11 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cuboid<N> {
 
         AABB::from_half_extents(center, ws_half_extents)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        let half_extents = Point::from(*self.half_extents());
+
+        AABB::new(-half_extents, half_extents)
+    }
 }

--- a/src/bounding_volume/aabb_heightfield.rs
+++ b/src/bounding_volume/aabb_heightfield.rs
@@ -6,7 +6,11 @@ use crate::shape::HeightField;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for HeightField<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        let bv = self.aabb();
-        bv.transform_by(m)
+        self.aabb().transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        self.aabb().clone()
     }
 }

--- a/src/bounding_volume/aabb_plane.rs
+++ b/src/bounding_volume/aabb_plane.rs
@@ -7,6 +7,11 @@ use crate::shape::Plane;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Plane<N> {
     #[inline]
     fn bounding_volume(&self, _: &Isometry<N>) -> AABB<N> {
+        self.local_bounding_volume()
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
         // We divide by 2.0  so that we can still make some operations with it (like loosening)
         // without breaking the box.
         let max = Point::max_value() * na::convert(0.5f64);

--- a/src/bounding_volume/aabb_polyline.rs
+++ b/src/bounding_volume/aabb_polyline.rs
@@ -6,7 +6,11 @@ use crate::shape::Polyline;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Polyline<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        let bv = self.aabb();
-        bv.transform_by(m)
+        self.aabb().transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        self.aabb().clone()
     }
 }

--- a/src/bounding_volume/aabb_segment.rs
+++ b/src/bounding_volume/aabb_segment.rs
@@ -4,10 +4,16 @@ use crate::shape::Segment;
 use crate::math::Matrix;
 use crate::math::{Point, Scalar, Vector};
 
-impl<N: RealField> HasBoundingVolume for Segment<N> {
+impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Segment<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        // FIXME: optimize that
-        bounding_volume::implicit_shape_aabb(m, self)
+        // SPEED: optimize this
+        bounding_volume::support_map_aabb(m, self)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        // SPEED: add `local_support_map_aabb` function to support map
+        bounding_volume::support_map_aabb(&Isometry::identity(), self)
     }
 }

--- a/src/bounding_volume/aabb_shape.rs
+++ b/src/bounding_volume/aabb_shape.rs
@@ -8,4 +8,9 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Shape<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         self.aabb(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        self.local_aabb()
+    }
 }

--- a/src/bounding_volume/aabb_support_map.rs
+++ b/src/bounding_volume/aabb_support_map.rs
@@ -12,6 +12,12 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cone<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         bounding_volume::support_map_aabb(m, self)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        // SPEED: add `local_support_map_aabb` function to support map
+        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+    }
 }
 
 #[cfg(feature = "dim3")]
@@ -20,6 +26,12 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Cylinder<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         bounding_volume::support_map_aabb(m, self)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        // SPEED: add `local_support_map_aabb` function to support map
+        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+    }
 }
 
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Capsule<N> {
@@ -27,12 +39,24 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Capsule<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
         bounding_volume::support_map_aabb(m, self)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        // SPEED: add `local_support_map_aabb` function to support map
+        bounding_volume::support_map_aabb(&Isometry::identity(), self)
+    }
 }
 
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Segment<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        // FIXME: optimize that
+        // SPEED: optimize this
         bounding_volume::support_map_aabb(m, self)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        // SPEED: add `local_support_map_aabb` function to support map
+        bounding_volume::support_map_aabb(&Isometry::identity(), self)
     }
 }

--- a/src/bounding_volume/aabb_triangle.rs
+++ b/src/bounding_volume/aabb_triangle.rs
@@ -22,6 +22,23 @@ impl<N: RealField> HasBoundingVolume<N, AABB<N>> for Triangle<N> {
 
         AABB::new(min, max)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        let a = self.a().coords;
+        let b = self.b().coords;
+        let c = self.c().coords;
+
+        let mut min = unsafe { Point::new_uninitialized() };
+        let mut max = unsafe { Point::new_uninitialized() };
+
+        for d in 0..DIM {
+            min.coords[d] = a[d].min(b[d]).min(c[d]);
+            max.coords[d] = a[d].max(b[d]).max(c[d]);
+        }
+
+        AABB::new(min, max)
+    }
 }
 
 #[cfg(test)]
@@ -47,5 +64,8 @@ mod test {
         );
 
         assert_eq!(t.aabb(&m), support_map_aabb(&m, &t));
+
+        // TODO: also test local AABB once support maps have a local AABB
+        // function too
     }
 }

--- a/src/bounding_volume/aabb_trimesh.rs
+++ b/src/bounding_volume/aabb_trimesh.rs
@@ -6,7 +6,11 @@ use crate::shape::TriMesh;
 impl<N: RealField> HasBoundingVolume<N, AABB<N>> for TriMesh<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> AABB<N> {
-        let bv = self.aabb();
-        bv.transform_by(m)
+        self.aabb().transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> AABB<N> {
+        self.aabb().clone()
     }
 }

--- a/src/bounding_volume/aabb_utils.rs
+++ b/src/bounding_volume/aabb_utils.rs
@@ -31,7 +31,7 @@ where
     AABB::new(Point::from(min), Point::from(max))
 }
 
-/// Computes the AABB of a set of point.
+/// Computes the AABB of a set of points transformed by `m`.
 pub fn point_cloud_aabb<'a, N: RealField, M: Transformation<Point<N>>, I>(m: &M, pts: I) -> AABB<N>
     where I: IntoIterator<Item = &'a Point<N>> {
     let mut it = pts.into_iter();
@@ -45,6 +45,23 @@ pub fn point_cloud_aabb<'a, N: RealField, M: Transformation<Point<N>>, I>(m: &M,
         let wpt = m.transform_point(pt);
         min = na::inf(&min, &wpt);
         max = na::sup(&max, &wpt);
+    }
+
+    AABB::new(min, max)
+}
+
+/// Computes the AABB of a set of points.
+pub fn local_point_cloud_aabb<'a, N: RealField, I>(pts: I) -> AABB<N>
+    where I: IntoIterator<Item = &'a Point<N>> {
+    let mut it = pts.into_iter();
+
+    let p0 = it.next().expect("Point cloud AABB construction: the input iterator should yield at least one point.");
+    let mut min: Point<N> = *p0;
+    let mut max: Point<N> = *p0;
+
+    for pt in it {
+        min = na::inf(&min, &pt);
+        max = na::sup(&max, &pt);
     }
 
     AABB::new(min, max)

--- a/src/bounding_volume/bounding_sphere.rs
+++ b/src/bounding_volume/bounding_sphere.rs
@@ -16,6 +16,18 @@ where
     g.bounding_volume(m)
 }
 
+// Seems useful to help type inference. See issue #84.
+/// Computes the bounding sphere of a shape `g`.
+///
+/// Same as `g.local_bounding_sphere(m)`.
+pub fn local_bounding_sphere<N, G: ?Sized>(g: &G) -> BoundingSphere<N>
+where
+    N: RealField,
+    G: HasBoundingVolume<N, BoundingSphere<N>>,
+{
+    g.local_bounding_volume()
+}
+
 /// A Bounding Sphere.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]

--- a/src/bounding_volume/bounding_sphere_ball.rs
+++ b/src/bounding_volume/bounding_sphere_ball.rs
@@ -6,9 +6,14 @@ use crate::shape::Ball;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Ball<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius = self.radius();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_capsule.rs
+++ b/src/bounding_volume/bounding_sphere_capsule.rs
@@ -6,9 +6,14 @@ use crate::shape::Capsule;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Capsule<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius = self.radius() + self.half_height();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_compound.rs
+++ b/src/bounding_volume/bounding_sphere_compound.rs
@@ -8,4 +8,9 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Compound<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         self.aabb().bounding_sphere().transform_by(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
+        self.aabb().bounding_sphere()
+    }
 }

--- a/src/bounding_volume/bounding_sphere_cone.rs
+++ b/src/bounding_volume/bounding_sphere_cone.rs
@@ -7,10 +7,15 @@ use crate::shape::Cone;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cone<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius =
             (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_convex.rs
+++ b/src/bounding_volume/bounding_sphere_convex.rs
@@ -7,8 +7,14 @@ use crate::shape::ConvexHull;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for ConvexHull<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(self.points());
 
-        BoundingSphere::new(m * center, radius)
+        BoundingSphere::new(center, radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_convex_polygon.rs
+++ b/src/bounding_volume/bounding_sphere_convex_polygon.rs
@@ -7,8 +7,14 @@ use crate::shape::ConvexPolygon;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for ConvexPolygon<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(self.points());
 
-        BoundingSphere::new(m * center, radius)
+        BoundingSphere::new(center, radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_cuboid.rs
+++ b/src/bounding_volume/bounding_sphere_cuboid.rs
@@ -6,9 +6,14 @@ use crate::shape::Cuboid;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cuboid<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius = self.half_extents().norm();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_cylinder.rs
+++ b/src/bounding_volume/bounding_sphere_cylinder.rs
@@ -7,10 +7,15 @@ use crate::shape::Cylinder;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Cylinder<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius =
             (self.radius() * self.radius() + self.half_height() * self.half_height()).sqrt();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_heightfield.rs
+++ b/src/bounding_volume/bounding_sphere_heightfield.rs
@@ -8,4 +8,9 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for HeightField<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         self.aabb().bounding_sphere().transform_by(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
+        self.aabb().bounding_sphere()
+    }
 }

--- a/src/bounding_volume/bounding_sphere_plane.rs
+++ b/src/bounding_volume/bounding_sphere_plane.rs
@@ -6,9 +6,14 @@ use crate::shape::Plane;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Plane<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
-        let center = Point::from(m.translation.vector);
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let radius = N::max_value();
 
-        BoundingSphere::new(center, radius)
+        BoundingSphere::new(Point::origin(), radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_polyline.rs
+++ b/src/bounding_volume/bounding_sphere_polyline.rs
@@ -9,4 +9,9 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Polyline<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         self.aabb().bounding_sphere().transform_by(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
+        self.aabb().bounding_sphere()
+    }
 }

--- a/src/bounding_volume/bounding_sphere_segment.rs
+++ b/src/bounding_volume/bounding_sphere_segment.rs
@@ -7,9 +7,15 @@ use crate::shape::Segment;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Segment<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let pts = [*self.a(), *self.b()];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 
-        BoundingSphere::new(m * center, radius)
+        BoundingSphere::new(center, radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_shape.rs
+++ b/src/bounding_volume/bounding_sphere_shape.rs
@@ -8,4 +8,9 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Shape<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         self.bounding_sphere(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
+        self.local_bounding_sphere()
+    }
 }

--- a/src/bounding_volume/bounding_sphere_triangle.rs
+++ b/src/bounding_volume/bounding_sphere_triangle.rs
@@ -7,9 +7,15 @@ use crate::shape::Triangle;
 impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for Triangle<N> {
     #[inline]
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
+        let bv: BoundingSphere<N> = self.local_bounding_volume();
+        bv.transform_by(m)
+    }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
         let pts = [*self.a(), *self.b(), *self.c()];
         let (center, radius) = bounding_volume::point_cloud_bounding_sphere(&pts[..]);
 
-        BoundingSphere::new(m * center, radius)
+        BoundingSphere::new(center, radius)
     }
 }

--- a/src/bounding_volume/bounding_sphere_trimesh.rs
+++ b/src/bounding_volume/bounding_sphere_trimesh.rs
@@ -8,4 +8,9 @@ impl<N: RealField> HasBoundingVolume<N, BoundingSphere<N>> for TriMesh<N> {
     fn bounding_volume(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         self.aabb().bounding_sphere().transform_by(m)
     }
+
+    #[inline]
+    fn local_bounding_volume(&self) -> BoundingSphere<N> {
+        self.aabb().bounding_sphere()
+    }
 }

--- a/src/bounding_volume/bounding_volume.rs
+++ b/src/bounding_volume/bounding_volume.rs
@@ -5,6 +5,10 @@ use na::RealField;
 pub trait HasBoundingVolume<N: RealField, BV> {
     /// The bounding volume of `self` transformed by `m`.
     fn bounding_volume(&self, m: &Isometry<N>) -> BV;
+    /// The bounding volume of `self`.
+    fn local_bounding_volume(&self) -> BV {
+        self.bounding_volume(&Isometry::identity())
+    }
 }
 
 /// Trait of bounding volumes.

--- a/src/bounding_volume/mod.rs
+++ b/src/bounding_volume/mod.rs
@@ -3,11 +3,11 @@
 pub use self::circular_cone::CircularCone;
 pub use self::spatialized_normal_cone::SpatializedNormalCone;
 #[doc(inline)]
-pub use crate::bounding_volume::aabb::{aabb, AABB};
+pub use crate::bounding_volume::aabb::{aabb, AABB, local_aabb};
 pub use crate::bounding_volume::aabb_ball::ball_aabb;
 pub use crate::bounding_volume::aabb_utils::{point_cloud_aabb, support_map_aabb};
 #[doc(inline)]
-pub use crate::bounding_volume::bounding_sphere::{bounding_sphere, BoundingSphere};
+pub use crate::bounding_volume::bounding_sphere::{bounding_sphere, BoundingSphere, local_bounding_sphere};
 pub use crate::bounding_volume::bounding_sphere_utils::{
     point_cloud_bounding_sphere, point_cloud_bounding_sphere_with_center,
 };

--- a/src/shape/polyline.rs
+++ b/src/shape/polyline.rs
@@ -79,7 +79,7 @@ impl<N: RealField> Polyline<N> {
                 let segment = Segment::new(points[is.x], points[is.y]);
                 let normal = segment.normal();
 
-                let bv = segment.aabb(&Isometry::identity());
+                let bv = segment.local_aabb();
                 leaves.push((i, bv.clone()));
                 edges.push(PolylineEdge {
                     indices: *is,

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -24,15 +24,28 @@ impl<N: RealField, T: 'static + Shape<N> + Clone> ShapeClone<N> for T {
 ///
 /// This allows dynamic inspection of the shape capabilities.
 pub trait Shape<N: RealField>: Send + Sync + Downcast + ShapeClone<N> {
-    /// The AABB of `self`.
+    /// The AABB of `self` transformed by `m`.
     #[inline]
     fn aabb(&self, m: &Isometry<N>) -> AABB<N>;
 
-    /// The bounding sphere of `self`.
+    /// The AABB of `self`.
+    #[inline]
+    fn local_aabb(&self) -> AABB<N> {
+        self.aabb(&Isometry::identity())
+    }
+
+    /// The bounding sphere of `self` transformed by `m`.
     #[inline]
     fn bounding_sphere(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         let aabb = self.aabb(m);
         BoundingSphere::new(aabb.center(), aabb.half_extents().norm_squared())
+    }
+
+    /// The bounding sphere of `self`.
+    #[inline]
+    fn local_bounding_sphere(&self) -> BoundingSphere<N> {
+        let aabb = self.local_aabb();
+        BoundingSphere::new(aabb.center(), aabb.half_extents().norm())
     }
 
     /// Check if if the feature `_feature` of the `i-th` subshape of `self` transformed by `m` has a tangent

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -38,7 +38,7 @@ pub trait Shape<N: RealField>: Send + Sync + Downcast + ShapeClone<N> {
     #[inline]
     fn bounding_sphere(&self, m: &Isometry<N>) -> BoundingSphere<N> {
         let aabb = self.aabb(m);
-        BoundingSphere::new(aabb.center(), aabb.half_extents().norm_squared())
+        BoundingSphere::new(aabb.center(), aabb.half_extents().norm())
     }
 
     /// The bounding sphere of `self`.

--- a/src/shape/shape_impl.rs
+++ b/src/shape/shape_impl.rs
@@ -86,6 +86,11 @@ macro_rules! impl_shape_common (
         }
 
         #[inline]
+        fn local_aabb(&self) -> AABB<N> {
+            bounding_volume::local_aabb(self)
+        }
+
+        #[inline]
         fn bounding_sphere(&self, m: &Isometry<N>) -> BoundingSphere<N> {
             bounding_volume::bounding_sphere(self, m)
         }
@@ -99,7 +104,6 @@ macro_rules! impl_shape_common (
         fn as_point_query(&self) -> Option<&PointQuery<N>> {
             Some(self)
         }
-
     }
 );
 

--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -127,7 +127,7 @@ impl<N: RealField> TriMesh<N> {
                     ]
                 });
 
-                let bv = triangle.aabb(&Isometry::identity());
+                let bv = triangle.local_aabb();
                 leaves.push((i, bv.clone()));
                 faces.push(TriMeshFace {
                     indices: *is,


### PR DESCRIPTION
Resolves #283. As discussed earlier, we should do the same thing for the support map trait in the future.