### PR TITLE
Fix benchmarks

### DIFF
--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -35,3 +35,6 @@ nalgebra   = "0.18"
 approx     = { version = "0.3", default-features = false }
 rand       = { version = "0.6", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
+
+[dev-dependencies]
+rand_isaac = "0.1"

--- a/build/ncollide3d/benches/bounding_volume/mod.rs
+++ b/build/ncollide3d/benches/bounding_volume/mod.rs
@@ -1,11 +1,11 @@
-use common::{generate, generate_trimesh_around_origin, unref};
+use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use ncollide3d::bounding_volume::{BoundingVolume, HasBoundingVolume};
 use ncollide3d::bounding_volume::{AABB, BoundingSphere};
 use ncollide3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle,
                         TriMesh};
-use rand::IsaacRng;
-use test;
+use rand::SeedableRng;
+use rand_isaac::IsaacRng;
 use test::Bencher;
 
 #[path = "../common/macros.rs"]

--- a/build/ncollide3d/benches/common/default_gen.rs
+++ b/build/ncollide3d/benches/common/default_gen.rs
@@ -53,7 +53,7 @@ impl_rand_default_gen!(bool);
 impl<N: RealField> DefaultGen for Ball<N>
     where Standard: Distribution<N> {
     fn generate<R: Rng>(rng: &mut R) -> Ball<N> {
-        Ball::new(na::abs(&rng.gen::<N>()))
+        Ball::new(rng.gen::<N>().abs())
     }
 }
 
@@ -67,21 +67,21 @@ impl<N: RealField> DefaultGen for Cuboid<N>
 impl<N: RealField> DefaultGen for Capsule<N>
     where Standard: Distribution<N> {
     fn generate<R: Rng>(rng: &mut R) -> Capsule<N> {
-        Capsule::new(na::abs(&rng.gen::<N>()), na::abs(&rng.gen::<N>()))
+        Capsule::new(rng.gen::<N>().abs(), rng.gen::<N>().abs())
     }
 }
 
 impl<N: RealField> DefaultGen for Cone<N>
     where Standard: Distribution<N> {
     fn generate<R: Rng>(rng: &mut R) -> Cone<N> {
-        Cone::new(na::abs(&rng.gen::<N>()), na::abs(&rng.gen::<N>()))
+        Cone::new(rng.gen::<N>().abs(), rng.gen::<N>().abs())
     }
 }
 
 impl<N: RealField> DefaultGen for Cylinder<N>
     where Standard: Distribution<N> {
     fn generate<R: Rng>(rng: &mut R) -> Cylinder<N> {
-        Cylinder::new(na::abs(&rng.gen::<N>()), na::abs(&rng.gen::<N>()))
+        Cylinder::new(rng.gen::<N>().abs(), rng.gen::<N>().abs())
     }
 }
 
@@ -137,6 +137,6 @@ impl<N: RealField> DefaultGen for BoundingSphere<N>
     where Standard: Distribution<N> {
     fn generate<R: Rng>(rng: &mut R) -> BoundingSphere<N> {
         // a bounding sphere centered at the origin.
-        BoundingSphere::new(na::origin(), na::abs(&rng.gen::<N>()))
+        BoundingSphere::new(Point3::origin(), rng.gen::<N>().abs())
     }
 }

--- a/build/ncollide3d/benches/common/macros.rs
+++ b/build/ncollide3d/benches/common/macros.rs
@@ -19,7 +19,7 @@ macro_rules! bench_free_fn_gen (
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 7;
 
-            let mut rng = IsaacRng::new_from_u64(0);
+            let mut rng: IsaacRng = SeedableRng::seed_from_u64(0);
 
             $(let $args: Vec<$types> = (0usize .. LEN).map(|_| $gens(&mut rng)).collect();)*
             let mut i = 0;
@@ -41,7 +41,7 @@ macro_rules! bench_method_gen (
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 7;
 
-            let mut rng = IsaacRng::new_from_u64(0);
+            let mut rng: IsaacRng = SeedableRng::seed_from_u64(0);
 
             let $arg: Vec<$typ> = (0usize .. LEN).map(|_| $gen(&mut rng)).collect();
             $(let $args: Vec<$types> = (0usize .. LEN).map(|_| $gens(&mut rng)).collect();)*
@@ -61,7 +61,7 @@ macro_rules! bench_method_gen (
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 7;
 
-            let mut rng = IsaacRng::new_from_u64(0);
+            let mut rng: IsaacRng = SeedableRng::seed_from_u64(0);
 
             let $arg: Vec<$typ> = (0usize .. LEN).map(|_| $gen(&mut rng)).collect();
             $(let $args: Vec<$types> = (0usize .. LEN).map(|_| $gens(&mut rng)).collect();)*

--- a/build/ncollide3d/benches/query/algorithm.rs
+++ b/build/ncollide3d/benches/query/algorithm.rs
@@ -1,6 +1,5 @@
 use na::Point3;
 use ncollide3d::query::algorithms::{CSOPoint, VoronoiSimplex};
-use test;
 use test::Bencher;
 
 #[bench]

--- a/build/ncollide3d/benches/query/contacts.rs
+++ b/build/ncollide3d/benches/query/contacts.rs
@@ -1,9 +1,9 @@
-use common::{generate, unref};
+use crate::common::{generate, unref};
 use na::Isometry3;
 use ncollide3d::query;
 use ncollide3d::shape::{Ball, Cuboid};
-use rand::IsaacRng;
-use test;
+use rand::SeedableRng;
+use rand_isaac::IsaacRng;
 use test::Bencher;
 
 #[path = "../common/macros.rs"]

--- a/build/ncollide3d/benches/query/ray.rs
+++ b/build/ncollide3d/benches/query/ray.rs
@@ -1,11 +1,11 @@
-use common::{generate, generate_trimesh_around_origin, unref};
+use crate::common::{generate, generate_trimesh_around_origin, unref};
 use na::Isometry3;
 use ncollide3d::bounding_volume::{AABB, BoundingSphere};
 use ncollide3d::query::{Ray, RayCast};
 use ncollide3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle,
                         TriMesh};
-use rand::IsaacRng;
-use test;
+use rand::SeedableRng;
+use rand_isaac::IsaacRng;
 use test::Bencher;
 
 #[path = "../common/macros.rs"]

--- a/build/ncollide3d/benches/support_map/mod.rs
+++ b/build/ncollide3d/benches/support_map/mod.rs
@@ -1,9 +1,9 @@
-use common::{generate, unref};
+use crate::common::{generate, unref};
 use na::{Isometry3, Vector3};
 use ncollide3d::shape::{Ball, Capsule, Cone, ConvexHull, Cuboid, Cylinder, Segment, Triangle};
 use ncollide3d::shape::SupportMap;
-use rand::IsaacRng;
-use test;
+use rand::SeedableRng;
+use rand_isaac::IsaacRng;
 use test::Bencher;
 
 #[path = "../common/macros.rs"]


### PR DESCRIPTION
Fixes compilation of the benchmarks. Additionally, resolves deprecation warnings from the nalgebra and rand crates. As a sidenote, I think we could be able to avoid the additional dependency to rand_isaac by switching to another random number generator, such as `XorShiftRng`.