### PR TITLE
Return the contact normal as a result of TOI computation

### DIFF
--- a/src/query/algorithms/gjk.rs
+++ b/src/query/algorithms/gjk.rs
@@ -224,8 +224,26 @@ where
     G1: SupportMap<N>,
     G2: SupportMap<N>,
 {
+    directional_distance_and_normal(m1, g1, m2, g2, dir, simplex).map(|res| res.0)
+}
+
+/// Compute the normal and the distance that can travel `g1` along the direction
+/// `dir` so that `g1` and `g2` just touch.
+pub fn directional_distance_and_normal<N, G1: ?Sized, G2: ?Sized>(
+    m1: &Isometry<N>,
+    g1: &G1,
+    m2: &Isometry<N>,
+    g2: &G2,
+    dir: &Vector<N>,
+    simplex: &mut VoronoiSimplex<N>,
+) -> Option<(N, Vector<N>)>
+where
+    N: RealField,
+    G1: SupportMap<N>,
+    G2: SupportMap<N>,
+{
     let ray = Ray::new(Point::origin(), *dir);
-    minkowski_ray_cast(m1, g1, m2, g2, &ray, simplex).map(|res| res.0)
+    minkowski_ray_cast(m1, g1, m2, g2, &ray, simplex)
 }
 
 // Ray-cast on the Minkowski Difference `m1 * g1 - m2 * g2`.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -22,7 +22,9 @@ pub use self::proximity_internal::Proximity;
 #[doc(inline)]
 pub use self::ray_internal::{Ray, RayCast, RayIntersection};
 #[doc(inline)]
-pub use self::time_of_impact_internal::time_of_impact;
+pub use self::time_of_impact_internal::{
+    time_of_impact, time_of_impact_and_normal,
+};
 
 pub mod algorithms;
 pub mod closest_points_internal;

--- a/src/query/ray_internal/mod.rs
+++ b/src/query/ray_internal/mod.rs
@@ -2,7 +2,7 @@
 
 #[doc(inline)]
 pub use self::ray::{Ray, RayCast, RayIntersection};
-pub use self::ray_ball::ball_toi_with_ray;
+pub use self::ray_ball::{ball_toi_with_ray, ball_toi_and_normal_with_ray};
 pub use self::ray_plane::{plane_toi_with_line, plane_toi_with_ray};
 pub use self::ray_support_map::implicit_toi_and_normal_with_ray;
 #[cfg(feature = "dim3")]

--- a/src/query/ray_internal/ray_ball.rs
+++ b/src/query/ray_internal/ray_ball.rs
@@ -41,15 +41,13 @@ impl<N: RealField> RayCast<N> for Ball<N> {
         solid: bool,
     ) -> Option<RayIntersection<N>>
     {
-        let center = Point::from(m.translation.vector);
-        let (inside, inter) = ball_toi_with_ray(&center, self.radius(), ray, solid);
-
-        inter.map(|n| {
-            let pos = ray.origin + ray.dir * n - center;
-            let normal = pos.normalize();
-
-            RayIntersection::new(n, if inside { -normal } else { normal }, FeatureId::Face(0))
-        })
+        ball_toi_and_normal_with_ray(
+            &Point::from(m.translation.vector),
+            self.radius(),
+            ray,
+            solid,
+        )
+        .1
     }
 
     #[cfg(feature = "dim3")]
@@ -112,4 +110,27 @@ pub fn ball_toi_with_ray<N: RealField>(
             }
         }
     }
+}
+
+
+/// Computes the time of impact and contact normal of a ray on a ball.
+#[inline]
+pub fn ball_toi_and_normal_with_ray<N: RealField>(
+    center: &Point<N>,
+    radius: N,
+    ray: &Ray<N>,
+    solid: bool,
+) -> (bool, Option<RayIntersection<N>>)
+{
+    let (inside, inter) = ball_toi_with_ray(&center, radius, ray, solid);
+
+    (
+        inside,
+        inter.map(|n| {
+            let pos = ray.origin + ray.dir * n - center;
+            let normal = pos.normalize();
+
+            RayIntersection::new(n, if inside { -normal } else { normal }, FeatureId::Face(0))
+        }),
+    )
 }

--- a/src/query/time_of_impact_internal/ball_against_ball.rs
+++ b/src/query/time_of_impact_internal/ball_against_ball.rs
@@ -4,7 +4,7 @@ use crate::math::{Point, Vector};
 use crate::query::{ray_internal, Ray};
 use crate::shape::Ball;
 
-/// Time Of Impact of two balls under translational movement.
+/// Time of impact of two balls under translational movement.
 #[inline]
 pub fn ball_against_ball<N: RealField>(
     center1: &Point<N>,
@@ -20,4 +20,22 @@ pub fn ball_against_ball<N: RealField>(
     let center = *center1 + (-center2.coords);
 
     ray_internal::ball_toi_with_ray(&center, radius, &Ray::new(Point::origin(), -vel), true).1
+}
+
+/// Time of impact and contact normal of two balls under translational movement.
+#[inline]
+pub fn ball_against_ball_with_normal<N: RealField>(
+    center1: &Point<N>,
+    vel1: &Vector<N>,
+    b1: &Ball<N>,
+    center2: &Point<N>,
+    vel2: &Vector<N>,
+    b2: &Ball<N>,
+) -> Option<(N, Vector<N>)>
+{
+    let vel = *vel1 - *vel2;
+    let radius = b1.radius() + b2.radius();
+    let center = *center1 + (-center2.coords);
+
+    ray_internal::ball_toi_and_normal_with_ray(&center, radius, &Ray::new(Point::origin(), -vel), true).1.map(|x| (x.toi, x.normal))
 }

--- a/src/query/time_of_impact_internal/composite_shape_against_shape.rs
+++ b/src/query/time_of_impact_internal/composite_shape_against_shape.rs
@@ -2,10 +2,10 @@ use crate::bounding_volume::AABB;
 use crate::math::{Isometry, Point, Vector};
 use na::{self, RealField};
 use crate::partitioning::{BestFirstBVVisitStatus, BestFirstDataVisitStatus, BestFirstVisitor};
-use crate::query::{time_of_impact_internal, Ray, RayCast};
+use crate::query::{Ray, RayCast, time_of_impact, time_of_impact_and_normal};
 use crate::shape::{CompositeShape, Shape};
 
-/// Time Of Impact of a composite shape with any other shape, under translational movement.
+/// Time of impact of a composite shape with any other shape, under translational movement.
 pub fn composite_shape_against_shape<N, G1: ?Sized>(
     m1: &Isometry<N>,
     vel1: &Vector<N>,
@@ -23,7 +23,7 @@ where
     g1.bvh().best_first_search(&mut visitor)
 }
 
-/// Time Of Impact of any shape with a composite shape, under translational movement.
+/// Time of impact of any shape with a composite shape, under translational movement.
 pub fn shape_against_composite_shape<N, G2: ?Sized>(
     m1: &Isometry<N>,
     vel1: &Vector<N>,
@@ -39,50 +39,108 @@ where
     composite_shape_against_shape(m2, vel2, g2, m1, vel1, g1)
 }
 
-struct CompositeShapeAgainstAnyTOIVisitor<'a, N: 'a + RealField, G1: ?Sized + 'a> {
-    msum_shift: Vector<N>,
-    msum_margin: Vector<N>,
-    ray: Ray<N>,
-
-    m1: &'a Isometry<N>,
-    vel1: &'a Vector<N>,
-    g1: &'a G1,
-    m2: &'a Isometry<N>,
-    vel2: &'a Vector<N>,
-    g2: &'a Shape<N>,
-}
-
-impl<'a, N, G1: ?Sized> CompositeShapeAgainstAnyTOIVisitor<'a, N, G1>
+/// Time of impact and contact normal of a composite shape with any other shape,
+/// under translational movement.
+pub fn composite_shape_against_shape_with_normal<N, G1: ?Sized>(
+    m1: &Isometry<N>,
+    vel1: &Vector<N>,
+    g1: &G1,
+    m2: &Isometry<N>,
+    vel2: &Vector<N>,
+    g2: &Shape<N>,
+) -> Option<(N, Vector<N>)>
 where
     N: RealField,
     G1: CompositeShape<N>,
 {
-    pub fn new(
-        m1: &'a Isometry<N>,
-        vel1: &'a Vector<N>,
-        g1: &'a G1,
-        m2: &'a Isometry<N>,
-        vel2: &'a Vector<N>,
-        g2: &'a Shape<N>,
-    ) -> CompositeShapeAgainstAnyTOIVisitor<'a, N, G1>
-    {
-        let ls_m2 = m1.inverse() * m2.clone();
-        let ls_aabb2 = g2.aabb(&ls_m2);
+    let mut visitor = CompositeShapeAgainstAnyTOIVisitorWithNormal::new(m1, vel1, g1, m2, vel2, g2);
 
-        CompositeShapeAgainstAnyTOIVisitor {
-            msum_shift: -ls_aabb2.center().coords,
-            msum_margin: ls_aabb2.half_extents(),
-            ray: Ray::new(
-                Point::origin(),
-                m1.inverse_transform_vector(&(*vel2 - *vel1)),
-            ),
-            m1: m1,
-            vel1: vel1,
-            g1: g1,
-            m2: m2,
-            vel2: vel2,
-            g2: g2,
+    g1.bvh().best_first_search(&mut visitor)
+}
+
+/// Time of impact and contact normal of any shape with a composite shape, under
+/// translational movement.
+pub fn shape_against_composite_shape_with_normal<N, G2: ?Sized>(
+    m1: &Isometry<N>,
+    vel1: &Vector<N>,
+    g1: &Shape<N>,
+    m2: &Isometry<N>,
+    vel2: &Vector<N>,
+    g2: &G2,
+) -> Option<(N, Vector<N>)>
+where
+    N: RealField,
+    G2: CompositeShape<N>,
+{
+    composite_shape_against_shape_with_normal(m2, vel2, g2, m1, vel1, g1).map(|x| (x.0, -x.1))
+}
+
+macro_rules! impl_composite_shape_visitor {
+    ($name:ident) => (
+        struct $name<'a, N: 'a + RealField, G1: ?Sized + 'a> {
+            msum_shift: Vector<N>,
+            msum_margin: Vector<N>,
+            ray: Ray<N>,
+
+            m1: &'a Isometry<N>,
+            vel1: &'a Vector<N>,
+            g1: &'a G1,
+            m2: &'a Isometry<N>,
+            vel2: &'a Vector<N>,
+            g2: &'a Shape<N>,
         }
+
+        impl<'a, N, G1: ?Sized> $name<'a, N, G1>
+        where
+            N: RealField,
+            G1: CompositeShape<N>,
+        {
+            pub fn new(
+                m1: &'a Isometry<N>,
+                vel1: &'a Vector<N>,
+                g1: &'a G1,
+                m2: &'a Isometry<N>,
+                vel2: &'a Vector<N>,
+                g2: &'a Shape<N>,
+            ) -> $name<'a, N, G1>
+            {
+                let ls_m2 = m1.inverse() * m2.clone();
+                let ls_aabb2 = g2.aabb(&ls_m2);
+
+                $name {
+                    msum_shift: -ls_aabb2.center().coords,
+                    msum_margin: ls_aabb2.half_extents(),
+                    ray: Ray::new(
+                        Point::origin(),
+                        m1.inverse_transform_vector(&(*vel2 - *vel1)),
+                    ),
+                    m1: m1,
+                    vel1: vel1,
+                    g1: g1,
+                    m2: m2,
+                    vel2: vel2,
+                    g2: g2,
+                }
+            }
+        }
+    )
+}
+
+impl_composite_shape_visitor!(CompositeShapeAgainstAnyTOIVisitor);
+impl_composite_shape_visitor!(CompositeShapeAgainstAnyTOIVisitorWithNormal);
+
+#[inline]
+fn visit_bv<N: RealField>(bv: &AABB<N>, msum_shift: &Vector<N>, msum_margin: &Vector<N>, ray: &Ray<N>) -> BestFirstBVVisitStatus<N> {
+    // Compute the minkowski sum of the two AABBs.
+    let msum = AABB::new(
+        *bv.mins() + msum_shift + (-msum_margin),
+        *bv.maxs() + msum_shift + msum_margin,
+    );
+
+    // Compute the TOI.
+    match msum.toi_with_ray(&Isometry::identity(), &ray, true) {
+        Some(toi) => BestFirstBVVisitStatus::ContinueWithCost(toi),
+        None => BestFirstBVVisitStatus::Stop,
     }
 }
 
@@ -96,29 +154,49 @@ where
 
     #[inline]
     fn visit_bv(&mut self, bv: &AABB<N>) -> BestFirstBVVisitStatus<N> {
-        // Compute the minkowski sum of the two AABBs.
-        let msum = AABB::new(
-            *bv.mins() + self.msum_shift + (-self.msum_margin),
-            *bv.maxs() + self.msum_shift + self.msum_margin,
-        );
-
-        // Compute the TOI.
-        match msum.toi_with_ray(&Isometry::identity(), &self.ray, true) {
-            Some(toi) => BestFirstBVVisitStatus::ContinueWithCost(toi),
-            None => BestFirstBVVisitStatus::Stop,
-        }
+        visit_bv(bv, &self.msum_shift, &self.msum_margin, &self.ray)
     }
 
     #[inline]
-    fn visit_data(&mut self, b: &usize) -> BestFirstDataVisitStatus<N, N> {
+    fn visit_data(&mut self, b: &usize) -> BestFirstDataVisitStatus<N, Self::Result> {
         let mut res = BestFirstDataVisitStatus::Continue;
 
         self.g1
             .map_part_at(*b, self.m1, &mut |m1, g1| {
-                if let Some(toi) = time_of_impact_internal::time_of_impact(
+                if let Some(toi) = time_of_impact(
                     m1, self.vel1, g1, self.m2, self.vel2, self.g2,
                 ) {
                     res = BestFirstDataVisitStatus::ContinueWithResult(toi, toi)
+                }
+            });
+
+        res
+    }
+}
+
+impl<'a, N, G1: ?Sized> BestFirstVisitor<N, usize, AABB<N>>
+    for CompositeShapeAgainstAnyTOIVisitorWithNormal<'a, N, G1>
+where
+    N: RealField,
+    G1: CompositeShape<N>,
+{
+    type Result = (N, Vector<N>);
+
+    #[inline]
+    fn visit_bv(&mut self, bv: &AABB<N>) -> BestFirstBVVisitStatus<N> {
+        visit_bv(bv, &self.msum_shift, &self.msum_margin, &self.ray)
+    }
+
+    #[inline]
+    fn visit_data(&mut self, b: &usize) -> BestFirstDataVisitStatus<N, Self::Result> {
+        let mut res = BestFirstDataVisitStatus::Continue;
+
+        self.g1
+            .map_part_at(*b, self.m1, &mut |m1, g1| {
+                if let Some((toi, normal)) = time_of_impact_and_normal(
+                    m1, self.vel1, g1, self.m2, self.vel2, self.g2,
+                ) {
+                    res = BestFirstDataVisitStatus::ContinueWithResult(toi, (toi, normal))
                 }
             });
 

--- a/src/query/time_of_impact_internal/mod.rs
+++ b/src/query/time_of_impact_internal/mod.rs
@@ -1,12 +1,24 @@
 //! Implementation details of the `time_of_impact` function.
 
-pub use self::ball_against_ball::ball_against_ball;
+pub use self::ball_against_ball::{
+    ball_against_ball, ball_against_ball_with_normal,
+};
 pub use self::composite_shape_against_shape::{
     composite_shape_against_shape, shape_against_composite_shape,
+    composite_shape_against_shape_with_normal,
+    shape_against_composite_shape_with_normal,
 };
-pub use self::plane_against_support_map::{plane_against_support_map, support_map_against_plane};
+pub use self::plane_against_support_map::{
+    plane_against_support_map, support_map_against_plane,
+    plane_against_support_map_with_normal,
+    support_map_against_plane_with_normal,
+};
 pub use self::shape_against_shape::shape_against_shape as time_of_impact;
-pub use self::support_map_against_support_map::support_map_against_support_map;
+pub use self::shape_against_shape::shape_against_shape_with_normal as time_of_impact_and_normal;
+pub use self::support_map_against_support_map::{
+    support_map_against_support_map,
+    support_map_against_support_map_with_normal,
+};
 
 mod ball_against_ball;
 mod composite_shape_against_shape;

--- a/src/query/time_of_impact_internal/plane_against_support_map.rs
+++ b/src/query/time_of_impact_internal/plane_against_support_map.rs
@@ -5,7 +5,7 @@ use crate::query::{Ray, RayCast};
 use crate::shape::Plane;
 use crate::shape::SupportMap;
 
-/// Time Of Impact of a plane with a support-mapped shape under translational movement.
+/// Time of impact of a plane with a support-mapped shape under translational movement.
 pub fn plane_against_support_map<N, G: ?Sized>(
     mplane: &Isometry<N>,
     vel_plane: &Vector<N>,
@@ -18,14 +18,31 @@ where
     N: RealField,
     G: SupportMap<N>,
 {
+    plane_against_support_map_with_normal(mplane, vel_plane, plane, mother, vel_other, other).map(|x| x.0)
+}
+
+/// Time of impact and contact normal of a plane with a support-mapped shape
+/// under translational movement.
+pub fn plane_against_support_map_with_normal<N, G: ?Sized>(
+    mplane: &Isometry<N>,
+    vel_plane: &Vector<N>,
+    plane: &Plane<N>,
+    mother: &Isometry<N>,
+    vel_other: &Vector<N>,
+    other: &G,
+) -> Option<(N, Vector<N>)>
+where
+    N: RealField,
+    G: SupportMap<N>,
+{
     let vel = *vel_other - *vel_plane;
     let plane_normal = mplane * plane.normal();
     let closest_point = other.support_point(mother, &-plane_normal);
 
-    plane.toi_with_ray(mplane, &Ray::new(closest_point, vel), true)
+    plane.toi_and_normal_with_ray(mplane, &Ray::new(closest_point, vel), true).map(|x| (x.toi, x.normal))
 }
 
-/// Time Of Impact of a plane with a support-mapped shape under translational movement.
+/// Time of impact of a plane with a support-mapped shape under translational movement.
 pub fn support_map_against_plane<N, G: ?Sized>(
     mother: &Isometry<N>,
     vel_other: &Vector<N>,
@@ -39,4 +56,21 @@ where
     G: SupportMap<N>,
 {
     plane_against_support_map(mplane, vel_plane, plane, mother, vel_other, other)
+}
+
+/// Time of impact and contact normal of a plane with a support-mapped shape
+/// under translational movement.
+pub fn support_map_against_plane_with_normal<N, G: ?Sized>(
+    mother: &Isometry<N>,
+    vel_other: &Vector<N>,
+    other: &G,
+    mplane: &Isometry<N>,
+    vel_plane: &Vector<N>,
+    plane: &Plane<N>,
+) -> Option<(N, Vector<N>)>
+where
+    N: RealField,
+    G: SupportMap<N>,
+{
+    plane_against_support_map_with_normal(mplane, vel_plane, plane, mother, vel_other, other).map(|x| (x.0, -x.1))
 }

--- a/src/query/time_of_impact_internal/shape_against_shape.rs
+++ b/src/query/time_of_impact_internal/shape_against_shape.rs
@@ -4,7 +4,8 @@ use crate::math::{Isometry, Point, Vector};
 use crate::query::time_of_impact_internal;
 use crate::shape::{Ball, Plane, Shape};
 
-/// Computes the smallest time of impact of two shapes under translational movement.
+/// Computes the smallest time of impact of two shapes under translational
+/// movement.
 ///
 /// Returns `0.0` if the objects are touching or penetrating.
 pub fn shape_against_shape<N: RealField>(
@@ -31,6 +32,42 @@ pub fn shape_against_shape<N: RealField>(
         time_of_impact_internal::composite_shape_against_shape(m1, vel1, c1, m2, vel2, g2)
     } else if let Some(c2) = g2.as_composite_shape() {
         time_of_impact_internal::shape_against_composite_shape(m1, vel1, g1, m2, vel2, c2)
+    } else {
+        panic!("No algorithm known to compute a contact point between the given pair of shapes.")
+    }
+}
+
+/// Computes the contact normal and the smallest time of impact of two shapes
+/// under translational movement.
+///
+/// The returned time of impact will be `0.0` if the objects are touching or
+/// penetrating.
+///
+/// The returned normal points toward the exterior of the first shape at the
+/// predicted impact point.
+pub fn shape_against_shape_with_normal<N: RealField>(
+    m1: &Isometry<N>,
+    vel1: &Vector<N>,
+    g1: &Shape<N>,
+    m2: &Isometry<N>,
+    vel2: &Vector<N>,
+    g2: &Shape<N>,
+) -> Option<(N, Vector<N>)> {
+    if let (Some(b1), Some(b2)) = (g1.as_shape::<Ball<N>>(), g2.as_shape::<Ball<N>>()) {
+        let p1 = Point::from(m1.translation.vector);
+        let p2 = Point::from(m2.translation.vector);
+
+        time_of_impact_internal::ball_against_ball_with_normal(&p1, vel1, b1, &p2, vel2, b2)
+    } else if let (Some(p1), Some(s2)) = (g1.as_shape::<Plane<N>>(), g2.as_support_map()) {
+        time_of_impact_internal::plane_against_support_map_with_normal(m1, vel1, p1, m2, vel2, s2)
+    } else if let (Some(s1), Some(p2)) = (g1.as_support_map(), g2.as_shape::<Plane<N>>()) {
+        time_of_impact_internal::support_map_against_plane_with_normal(m1, vel1, s1, m2, vel2, p2)
+    } else if let (Some(s1), Some(s2)) = (g1.as_support_map(), g2.as_support_map()) {
+        time_of_impact_internal::support_map_against_support_map_with_normal(m1, vel1, s1, m2, vel2, s2)
+    } else if let Some(c1) = g1.as_composite_shape() {
+        time_of_impact_internal::composite_shape_against_shape_with_normal(m1, vel1, c1, m2, vel2, g2)
+    } else if let Some(c2) = g2.as_composite_shape() {
+        time_of_impact_internal::shape_against_composite_shape_with_normal(m1, vel1, g1, m2, vel2, c2)
     } else {
         panic!("No algorithm known to compute a contact point between the given pair of shapes.")
     }

--- a/src/query/time_of_impact_internal/support_map_against_support_map.rs
+++ b/src/query/time_of_impact_internal/support_map_against_support_map.rs
@@ -4,7 +4,7 @@ use crate::math::{Isometry, Vector};
 use crate::query::algorithms::{gjk, VoronoiSimplex};
 use crate::shape::SupportMap;
 
-/// Time of impacts between two support-mapped shapes under translational movement.
+/// Time of impact between two support-mapped shapes under translational movement.
 pub fn support_map_against_support_map<N, G1: ?Sized, G2: ?Sized>(
     m1: &Isometry<N>,
     vel1: &Vector<N>,
@@ -20,4 +20,23 @@ where
 {
     let dvel = vel2 - vel1;
     gjk::directional_distance(m1, g1, m2, g2, &dvel, &mut VoronoiSimplex::new())
+}
+
+/// Time of impact and contact normal between two support-mapped shapes under
+/// translational movement.
+pub fn support_map_against_support_map_with_normal<N, G1: ?Sized, G2: ?Sized>(
+    m1: &Isometry<N>,
+    vel1: &Vector<N>,
+    g1: &G1,
+    m2: &Isometry<N>,
+    vel2: &Vector<N>,
+    g2: &G2,
+) -> Option<(N, Vector<N>)>
+where
+    N: RealField,
+    G1: SupportMap<N>,
+    G2: SupportMap<N>,
+{
+    let dvel = vel2 - vel1;
+    gjk::directional_distance_and_normal(m1, g1, m2, g2, &dvel, &mut VoronoiSimplex::new())
 }

--- a/src/query/time_of_impact_internal/time_of_impact_with.rs
+++ b/src/query/time_of_impact_internal/time_of_impact_with.rs
@@ -9,16 +9,16 @@ use traits::Shape;
 use time_of_impact_internal;
 use math::{Scalar, Point, Vector, Isometry};
 
-/// Trait implemented by object that can have their Time Of Impact under translational movement
+/// Trait implemented by object that can have their time of impact under translational movement
 /// computed.
 pub trait TimeOfImpactWith<N, P, V, M, G: ?Sized> for Sized? {
-    /// Computes the Time Of Impact separating two shapes.
+    /// Computes the time of impact separating two shapes.
     ///
     /// Returns `None` if they never move.
     fn time_of_impact(m1: &Isometry<N>, vel1: &V, g1: &Self, m2: &Isometry<N>, vel2: &V, g2: &G) -> Option<N>;
 }
 
-/// Computes the Time Of Impact separating two shapes under translational movement.
+/// Computes the time of impact separating two shapes under translational movement.
 pub fn time_of_impact<N, P, V, M, G1: ?Sized, G2: ?Sized>(m1: &Isometry<N>, vel1: &V, g1: &G1,
                                                           m2: &Isometry<N>, vel2: &V, g2: &G2)
                                                           -> Option<N>


### PR DESCRIPTION
Resolves #34. Provides an additional `query::time_of_impact_and_normal` function which returns the contact normal in addition to the time of impact. I decided to make this into a new function in order to avoid a breaking change. In the future it might make sense to combine these two functions into a single function that returns a struct, perhaps similar to the existing `RayIntersection` struct. Please let me know if any of this needs changing to accommodate a different design or whatnot.