### PR TITLE
Make rand dependency a dev-dependency

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -33,5 +33,7 @@ petgraph        = "0.4"
 alga            = "0.9"
 nalgebra        = "0.18"
 approx          = { version = "0.3", default-features = false }
-rand            = { version = "0.6", default-features = false }
 serde           = { version = "1.0", optional = true, features = ["derive"]}
+
+[dev-dependencies]
+rand            = { version = "0.6", default-features = false }

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -33,5 +33,7 @@ petgraph   = "0.4"
 alga       = "0.9"
 nalgebra   = "0.18"
 approx     = { version = "0.3", default-features = false }
-rand       = { version = "0.6", default-features = false }
 serde      = { version = "1.0", optional = true, features = ["derive", "rc"]}
+
+[dev-dependencies]
+rand       = { version = "0.6", default-features = false }


### PR DESCRIPTION
The rand crate is only used in benchmarks, so it doesn't need to be a dependency of this crate, but can be a dev-dependency instead. rand is still a transitive dependency of nalgebra, but still, this simplifies the dependency graph a little bit.