### PR TITLE
Remove extraneous Clone bound on ShapeHandle::new()

### DIFF
--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -166,7 +166,7 @@ pub struct ShapeHandle<N: RealField>(Arc<Box<Shape<N>>>);
 impl<N: RealField> ShapeHandle<N> {
     /// Creates a sharable shape handle from a shape.
     #[inline]
-    pub fn new<S: Shape<N> + Clone>(shape: S) -> ShapeHandle<N> {
+    pub fn new<S: Shape<N>>(shape: S) -> ShapeHandle<N> {
         ShapeHandle(Arc::new(Box::new(shape)))
     }
 

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -170,6 +170,11 @@ impl<N: RealField> ShapeHandle<N> {
         ShapeHandle(Arc::new(Box::new(shape)))
     }
 
+    /// Creates a sharable shape handle from a shape trait object.
+    pub fn new_from_box(shape: Box<Shape<N>>) -> ShapeHandle<N> {
+        ShapeHandle(Arc::new(shape))
+    }
+
     pub(crate) fn make_mut(&mut self) -> &mut Shape<N> {
         &mut **Arc::make_mut(&mut self.0)
     }

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -171,7 +171,7 @@ impl<N: RealField> ShapeHandle<N> {
     }
 
     /// Creates a sharable shape handle from a shape trait object.
-    pub fn new_from_box(shape: Box<Shape<N>>) -> ShapeHandle<N> {
+    pub fn from_box(shape: Box<Shape<N>>) -> ShapeHandle<N> {
         ShapeHandle(Arc::new(shape))
     }
 


### PR DESCRIPTION
Tested locally and doesn't cause problems when `cargo test` is called.

This would allow ShapeHandle's to be created in cases where the concrete type of the Shape isn't known, allowing the user to pass in their Shapes as trait objects.