### PR TITLE
Segment::support_face_toward: clear the output buffer before filling it.

### DIFF
--- a/src/shape/segment.rs
+++ b/src/shape/segment.rs
@@ -296,6 +296,7 @@ impl<N: RealField> ConvexPolyhedron<N> for Segment<N> {
         face: &mut ConvexPolygonalFeature<N>,
     )
     {
+        face.clear();
         face.push(self.a, FeatureId::Vertex(0));
         face.push(self.b, FeatureId::Vertex(1));
         face.push_edge_feature_id(FeatureId::Edge(0));


### PR DESCRIPTION
The lack of clear did break 3D come collision detections with segments (which includes collision detection with capsules).