### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/shape/trimesh.rs
+++ b/src/shape/trimesh.rs
@@ -530,7 +530,7 @@ impl<N: RealField> TriMesh<N> {
         let e = &self.edges[i];
 
         if let Some(coords) = deformations {
-            for adj_face in [e.adj_faces.0.face_id, e.adj_faces.1.face_id].into_iter() {
+            for adj_face in [e.adj_faces.0.face_id, e.adj_faces.1.face_id].iter() {
                 let indices = self.faces[*adj_face].indices * DIM;
                 let tri = Triangle::new(
                     Point::from_slice(&coords[indices.x..indices.x + DIM]),
@@ -543,7 +543,7 @@ impl<N: RealField> TriMesh<N> {
                 }
             }
         } else {
-            for adj_face in [e.adj_faces.0.face_id, e.adj_faces.1.face_id].into_iter() {
+            for adj_face in [e.adj_faces.0.face_id, e.adj_faces.1.face_id].iter() {
                 let face = &self.faces[*adj_face];
 
                 if let Some(ref n) = face.normal {


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.