### PR TITLE
First interference with ray

### DIFF
--- a/build/ncollide2d/examples/first_ray_intersect.rs
+++ b/build/ncollide2d/examples/first_ray_intersect.rs
@@ -1,0 +1,60 @@
+extern crate nalgebra as na;
+extern crate ncollide2d;
+
+use na::{Isometry2, Point2, Vector2};
+use ncollide2d::pipeline::{CollisionGroups, GeometricQueryType};
+use ncollide2d::query::Ray;
+use ncollide2d::shape::{Ball, Cuboid, ShapeHandle};
+use ncollide2d::world::CollisionWorld;
+
+fn main() {
+    let ball1 = Ball::new(0.5);
+    let ball2 = Ball::new(0.75);
+    let cube1 = Cuboid::new(Vector2::new(0.5, 0.75));
+    let cube2 = Cuboid::new(Vector2::new(1.0, 0.5));
+
+    let shapes = [
+        ShapeHandle::new(ball1),
+        ShapeHandle::new(ball2),
+        ShapeHandle::new(cube1),
+        ShapeHandle::new(cube2),
+    ];
+
+    let poss = [
+        Isometry2::new(Vector2::new(1.0, 0.0), na::zero()),
+        Isometry2::new(Vector2::new(2.0, 0.0), na::zero()),
+        Isometry2::new(Vector2::new(3.0, 0.0), na::zero()),
+        Isometry2::new(Vector2::new(4.0, 2.0), na::zero()),
+    ];
+
+    let mut world = CollisionWorld::new(0.02);
+    let collision_group = CollisionGroups::new();
+    let query_type = GeometricQueryType::Contacts(0.0, 0.0);
+
+    let z = shapes.iter().zip(&poss);
+    for (shape, pos) in z {
+        world.add(*pos, shape.clone(), collision_group, query_type, ());
+    }
+
+    world.update();
+
+    let ray_hit = Ray::<f32>::new(Point2::origin(), Vector2::x());
+    let ray_miss = Ray::<f32>::new(Point2::origin(), -Vector2::x());
+
+    let hit = world
+        .first_interference_with_ray(&ray_hit, &collision_group)
+        .expect("Hit missed");
+    let miss = world.first_interference_with_ray(&ray_miss, &collision_group);
+
+    // println!("Hit: {:#?}", hit);
+    // println!("Miss: {:#?}", miss);
+
+    println!("Hit: {:?}", hit.inter);
+
+    assert!(hit.inter.toi == 0.5);
+    assert!(miss.is_none());
+
+    // First object is a circle with radius 0.5 centered at (1.0, 0.0)
+    // assert!(hit_toi == 0.5);
+    // assert!(collector_miss.len() == 0);
+}

--- a/build/ncollide2d/examples/first_ray_intersect.rs
+++ b/build/ncollide2d/examples/first_ray_intersect.rs
@@ -36,6 +36,7 @@ fn main() {
         world.add(*pos, shape.clone(), collision_group, query_type, ());
     }
 
+    // Need to run update so all of the deferred functions are run (including adding shapes)
     world.update();
 
     let ray_hit = Ray::<f32>::new(Point2::origin(), Vector2::x());
@@ -46,15 +47,9 @@ fn main() {
         .expect("Hit missed");
     let miss = world.first_interference_with_ray(&ray_miss, &collision_group);
 
-    // println!("Hit: {:#?}", hit);
-    // println!("Miss: {:#?}", miss);
-
     println!("Hit: {:?}", hit.inter);
 
+    // First object is a circle with radius 0.5 centered at (1.0, 0.0)
     assert!(hit.inter.toi == 0.5);
     assert!(miss.is_none());
-
-    // First object is a circle with radius 0.5 centered at (1.0, 0.0)
-    // assert!(hit_toi == 0.5);
-    // assert!(collector_miss.len() == 0);
 }

--- a/src/partitioning/bvh.rs
+++ b/src/partitioning/bvh.rs
@@ -94,7 +94,7 @@ pub trait BVH<T, BV> {
         }
     }
 
-    /// Performs a best-fist-search on the BVH.
+    /// Performs a best-first-search on the BVH.
     ///
     /// Returns the content of the leaf with the smallest associated cost, and a result of
     /// user-defined type.

--- a/src/pipeline/broad_phase/broad_phase.rs
+++ b/src/pipeline/broad_phase/broad_phase.rs
@@ -2,7 +2,7 @@ use na::RealField;
 use std::any::Any;
 
 use crate::math::Point;
-use crate::query::Ray;
+use crate::query::{Ray, RayIntersection};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BroadPhaseProxyHandle(pub usize);
@@ -76,4 +76,10 @@ pub trait BroadPhase<N: RealField, BV, T>: Any + Sync + Send {
 
     /// Collects every object which might contain a given point.
     fn interferences_with_point<'a>(&'a self, point: &Point<N>, out: &mut Vec<&'a T>);
+
+    fn interference_cost_fn_with_ray<'a, 'b>(
+        &'a self,
+        ray: &'b Ray<N>,
+        cost_fn: &'a dyn Fn(T, &'b Ray<N>) -> Option<(T, RayIntersection<N>)>,
+    ) -> Option<(T, RayIntersection<N>)>;
 }

--- a/src/pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/src/pipeline/broad_phase/dbvt_broad_phase.rs
@@ -5,7 +5,7 @@ use crate::pipeline::broad_phase::{
     BroadPhase, BroadPhaseInterferenceHandler, BroadPhaseProxyHandle,
 };
 use crate::query::visitors::{
-    BoundingVolumeInterferencesCollector, FirstRayInterferenceVisitor, PointInterferencesCollector,
+    BoundingVolumeInterferencesCollector, RayIntersectionCostFnVisitor, PointInterferencesCollector,
     RayInterferencesCollector,
 };
 use crate::query::{PointQuery, Ray, RayCast, RayIntersection};
@@ -437,7 +437,7 @@ where
     ) -> Option<(T, RayIntersection<N>)> {
         let res = {
             let mut visitor =
-                FirstRayInterferenceVisitor::<'a, 'b, N, T, BV>::new(ray, self, cost_fn);
+                RayIntersectionCostFnVisitor::<'a, 'b, N, T, BV>::new(ray, self, cost_fn);
 
             let dynamic_hit = self.tree.best_first_search(&mut visitor);
             let static_hit = self.stree.best_first_search(&mut visitor);

--- a/src/pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/src/pipeline/broad_phase/dbvt_broad_phase.rs
@@ -437,10 +437,18 @@ where
     ) -> Option<(T, RayIntersection<N>)> {
         let res = {
             let mut visitor =
-                FirstRayInterferenceVisitor::<'a, 'b, N, T, BV>::new(ray, true, self, cost_fn);
+                FirstRayInterferenceVisitor::<'a, 'b, N, T, BV>::new(ray, self, cost_fn);
 
-            let _ = self.tree.best_first_search(&mut visitor);
-            self.stree.best_first_search(&mut visitor)
+            let dynamic_hit = self.tree.best_first_search(&mut visitor);
+            let static_hit = self.stree.best_first_search(&mut visitor);
+
+            // The static hit must be better than the dynamic hit as it uses the
+            // same visitor so give it priority
+            if static_hit.is_some() {
+                static_hit
+            } else {
+                dynamic_hit
+            }
         };
 
         if let Some((_node, res)) = res {

--- a/src/pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/src/pipeline/broad_phase/dbvt_broad_phase.rs
@@ -5,8 +5,8 @@ use crate::pipeline::broad_phase::{
     BroadPhase, BroadPhaseInterferenceHandler, BroadPhaseProxyHandle,
 };
 use crate::query::visitors::{
-    BoundingVolumeInterferencesCollector, RayIntersectionCostFnVisitor, PointInterferencesCollector,
-    RayInterferencesCollector,
+    BoundingVolumeInterferencesCollector, PointInterferencesCollector, RayInterferencesCollector,
+    RayIntersectionCostFnVisitor,
 };
 use crate::query::{PointQuery, Ray, RayCast, RayIntersection};
 use crate::utils::{DeterministicState, SortedPair};

--- a/src/pipeline/glue/mod.rs
+++ b/src/pipeline/glue/mod.rs
@@ -1,8 +1,9 @@
 //! Glue code between each part of the collision-detection pipeline.
 
 pub use self::query::{
-    interferences_with_aabb, interferences_with_point, interferences_with_ray,
-    InterferencesWithAABB, InterferencesWithPoint, InterferencesWithRay,
+    first_interference_with_ray, interferences_with_aabb, interferences_with_point,
+    interferences_with_ray, FirstInterferenceWithRay, InterferencesWithAABB,
+    InterferencesWithPoint, InterferencesWithRay,
 };
 pub use setup::{
     create_proxies, default_broad_phase, default_interaction_graph, default_narrow_phase,

--- a/src/pipeline/glue/query.rs
+++ b/src/pipeline/glue/query.rs
@@ -193,7 +193,7 @@ where
     Objects: CollisionObjectSet<N>,
 {
     // Narrow phase
-    let narrow_phase = |handle: Objects::CollisionObjectHandle, ray:  &Ray<N>| {
+    let narrow_phase = move |handle: Objects::CollisionObjectHandle, ray:  &Ray<N>| {
         if let Some(co) = objects.collision_object(handle) {
             if co.collision_groups().can_interact_with_groups(groups) {
                 let inter = co
@@ -201,12 +201,20 @@ where
                     .toi_and_normal_with_ray(&co.position(), ray, true);
 
                 if let Some(inter) = inter {
-                    return Some((handle, co, inter));
+                    return Some((handle, inter));
                 }
             }
         }
         None
     };
 
-    broad_phase.first_interference_with_ray::<Objects>(ray, &narrow_phase)
+    let mut res = None;
+
+    if let Some((handle, inter)) = broad_phase.first_interference_with_ray::<Objects>(ray, &narrow_phase) {
+        if let Some(co) = objects.collision_object(handle) {
+            res = Some((handle, co, inter));
+        }
+    }
+
+    res
 }

--- a/src/pipeline/glue/query.rs
+++ b/src/pipeline/glue/query.rs
@@ -179,10 +179,7 @@ impl<'a, 'b, N: RealField, Objects: CollisionObjectSet<N>> Iterator
 /// Contains the handle of the closest object along the ray along with its
 /// intersection details
 #[derive(Debug)]
-pub struct FirstInterferenceWithRay<'a, N, Objects>
-where
-    N: RealField,
-    Objects: CollisionObjectSet<N>,
+pub struct FirstInterferenceWithRay<'a, N: RealField, Objects: CollisionObjectSet<N>>
 {
     /// Handle to the object the ray collided with.
     pub handle: Objects::CollisionObjectHandle,
@@ -195,15 +192,12 @@ where
 /// Returns an the closest collision object intersecting with the given ray.
 ///
 /// The result will only include collision objects in a group that can interact with the given `groups`.
-pub fn first_interference_with_ray<'a, 'b, N, Objects>(
+pub fn first_interference_with_ray<'a, 'b, N: RealField, Objects: CollisionObjectSet<N>>(
     objects: &'a Objects,
     broad_phase: &'a (impl BroadPhase<N, AABB<N>, Objects::CollisionObjectHandle> + ?Sized),
     ray: &'b Ray<N>,
     groups: &'b CollisionGroups,
 ) -> Option<FirstInterferenceWithRay<'a, N, Objects>>
-where
-    N: RealField,
-    Objects: CollisionObjectSet<N>,
 {
     // Narrow phase
     let narrow_phase = move |handle: Objects::CollisionObjectHandle, ray: &Ray<N>| {

--- a/src/pipeline/glue/query.rs
+++ b/src/pipeline/glue/query.rs
@@ -179,8 +179,7 @@ impl<'a, 'b, N: RealField, Objects: CollisionObjectSet<N>> Iterator
 /// Contains the handle of the closest object along the ray along with its
 /// intersection details
 #[derive(Debug)]
-pub struct FirstInterferenceWithRay<'a, N: RealField, Objects: CollisionObjectSet<N>>
-{
+pub struct FirstInterferenceWithRay<'a, N: RealField, Objects: CollisionObjectSet<N>> {
     /// Handle to the object the ray collided with.
     pub handle: Objects::CollisionObjectHandle,
     /// Reference to the object the ray collided with.
@@ -197,8 +196,7 @@ pub fn first_interference_with_ray<'a, 'b, N: RealField, Objects: CollisionObjec
     broad_phase: &'a (impl BroadPhase<N, AABB<N>, Objects::CollisionObjectHandle> + ?Sized),
     ray: &'b Ray<N>,
     groups: &'b CollisionGroups,
-) -> Option<FirstInterferenceWithRay<'a, N, Objects>>
-{
+) -> Option<FirstInterferenceWithRay<'a, N, Objects>> {
     // Narrow phase
     let narrow_phase = move |handle: Objects::CollisionObjectHandle, ray: &Ray<N>| {
         if let Some(co) = objects.collision_object(handle) {

--- a/src/pipeline/world.rs
+++ b/src/pipeline/world.rs
@@ -6,7 +6,8 @@ use crate::bounding_volume::{BoundingVolume, AABB};
 use crate::math::{Isometry, Point, Rotation, Translation, Vector};
 use crate::pipeline::broad_phase::{BroadPhase, BroadPhasePairFilter, DBVTBroadPhase};
 use crate::pipeline::glue::{
-    self, InterferencesWithAABB, InterferencesWithPoint, InterferencesWithRay,
+    self, FirstInterferenceWithRay, InterferencesWithAABB, InterferencesWithPoint,
+    InterferencesWithRay,
 };
 use crate::pipeline::narrow_phase::{
     ContactAlgorithm, ContactEvents, DefaultContactDispatcher, DefaultProximityDispatcher,
@@ -341,6 +342,16 @@ impl<N: RealField, T> CollisionWorld<N, T> {
         groups: &'b CollisionGroups,
     ) -> InterferencesWithRay<'a, 'b, N, CollisionObjectSlab<N, T>> {
         glue::interferences_with_ray(&self.objects, &*self.broad_phase, ray, groups)
+    }
+
+    /// Computes the interferences between every rigid bodies on this world and a ray.
+    #[inline]
+    pub fn first_interference_with_ray<'a, 'b>(
+        &'a self,
+        ray: &'b Ray<N>,
+        groups: &'b CollisionGroups,
+    ) -> Option<FirstInterferenceWithRay<'a, N, CollisionObjectSlab<N, T>>> {
+        glue::first_interference_with_ray(&self.objects, &*self.broad_phase, ray, groups)
     }
 
     /// Computes the interferences between every rigid bodies of a given broad phase, and a point.

--- a/src/query/visitors/first_ray_interference_visitor.rs
+++ b/src/query/visitors/first_ray_interference_visitor.rs
@@ -1,18 +1,16 @@
-use crate::math::Isometry;
-use crate::partitioning::{BestFirstVisitor, BestFirstVisitStatus};
-use crate::query::{Ray, RayCast, RayIntersection, PointQuery};
-use na::RealField;
 use crate::bounding_volume::BoundingVolume;
+use crate::math::Isometry;
+use crate::partitioning::{BestFirstVisitStatus, BestFirstVisitor};
+use crate::query::{PointQuery, Ray, RayCast, RayIntersection};
+use na::RealField;
 use std::any::Any;
 
-use crate::pipeline::{DBVTBroadPhase, BroadPhaseProxyHandle, BroadPhase};
-use crate::pipeline::object::{CollisionObjectSet};
-
+use crate::pipeline::object::CollisionObjectSet;
+use crate::pipeline::{BroadPhase, BroadPhaseProxyHandle, DBVTBroadPhase};
 
 /// Bounding Volume Tree visitor collecting interferences with a given ray.
-pub struct FirstRayInterferenceVisitor<'a, 'b, N: 'a + RealField, T, BV, Objects>
+pub struct FirstRayInterferenceVisitor<'a, 'b, N: 'a + RealField, T, BV>
 where
-    Objects: CollisionObjectSet<N>,
     BV: BoundingVolume<N> + RayCast<N> + PointQuery<N> + Any + Send + Sync + Clone,
     T: Any + Send + Sync,
 {
@@ -20,25 +18,22 @@ where
     ray: &'b Ray<N>,
     solid: bool,
     handles: &'a DBVTBroadPhase<N, BV, T>,
-    narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(
-        Objects::CollisionObjectHandle,
-        RayIntersection<N>,
-    )>,
+    narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(T, RayIntersection<N>)>,
 }
 
-impl<'a, 'b, N: RealField, T, BV, Objects> FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects>
+impl<'a, 'b, N: RealField, T, BV> FirstRayInterferenceVisitor<'a, 'b, N, T, BV>
 where
-    Objects: CollisionObjectSet<N>,
     BV: BoundingVolume<N> + RayCast<N> + PointQuery<N> + Any + Send + Sync + Clone,
     T: Any + Send + Sync,
 {
     /// Creates a new `FirstRayInterferenceVisitor`.
     #[inline]
-    pub fn new(ray: &'b Ray<N>, solid: bool, handles: &'a DBVTBroadPhase<N, BV, T>, narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(
-        Objects::CollisionObjectHandle,
-        RayIntersection<N>,
-    )> ) ->
-    FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects> {
+    pub fn new(
+        ray: &'b Ray<N>,
+        solid: bool,
+        handles: &'a DBVTBroadPhase<N, BV, T>,
+        narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(T, RayIntersection<N>)>,
+    ) -> FirstRayInterferenceVisitor<'a, 'b, N, T, BV> {
         FirstRayInterferenceVisitor {
             ray,
             solid,
@@ -48,18 +43,14 @@ where
     }
 }
 
-
-impl<'a, 'b, N, BV, T, Objects> BestFirstVisitor<N, BroadPhaseProxyHandle, BV> for FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects>
+impl<'a, 'b, N, BV, T> BestFirstVisitor<N, BroadPhaseProxyHandle, BV>
+    for FirstRayInterferenceVisitor<'a, 'b, N, T, BV>
 where
     N: RealField,
-    Objects: CollisionObjectSet<N>,
     BV: BoundingVolume<N> + RayCast<N> + PointQuery<N> + Any + Send + Sync + Clone,
     T: Any + Send + Sync + Clone,
 {
-    type Result = (
-        Objects::CollisionObjectHandle,
-        RayIntersection<N>,
-    );
+    type Result = (T, RayIntersection<N>);
 
     #[inline]
     fn visit(
@@ -70,13 +61,19 @@ where
     ) -> BestFirstVisitStatus<N, Self::Result> {
         let mut res = BestFirstVisitStatus::Stop;
         if let Some(rough_toi) = bv.toi_with_ray(&Isometry::identity(), self.ray, self.solid) {
-            res = BestFirstVisitStatus::Continue {cost: rough_toi, result: None};
+            res = BestFirstVisitStatus::Continue {
+                cost: rough_toi,
+                result: None,
+            };
 
             if rough_toi < best_cost_so_far {
                 if let Some(handle) = value {
                     if let Some((_, narrow_handle)) = self.handles.proxy(*handle) {
                         if let Some(result) = (self.narrow_phase)(narrow_handle.clone(), self.ray) {
-                            res = BestFirstVisitStatus::Continue {cost: result.1.toi, result: Some(result)};
+                            res = BestFirstVisitStatus::Continue {
+                                cost: result.1.toi,
+                                result: Some(result),
+                            };
                         }
                     }
                 };

--- a/src/query/visitors/first_ray_interference_visitor.rs
+++ b/src/query/visitors/first_ray_interference_visitor.rs
@@ -1,0 +1,86 @@
+use crate::math::Isometry;
+use crate::partitioning::{BestFirstVisitor, BestFirstVisitStatus};
+use crate::query::{Ray, RayCast, RayIntersection};
+use na::RealField;
+
+use crate::pipeline::{DBVTBroadPhase, BroadPhaseProxyHandle};
+use crate::pipeline::object::{CollisionObjectSet};
+
+
+/// Bounding Volume Tree visitor collecting interferences with a given ray.
+pub struct FirstRayInterferenceVisitor<'a, 'b, N: 'a + RealField, T, BV, Objects>
+where
+    Objects: CollisionObjectSet<N>,
+{
+    /// Ray to be tested.
+    ray: &'b Ray<N>,
+    solid: bool,
+    handles: &'a DBVTBroadPhase<N, BV, T>,
+    narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(
+        Objects::CollisionObjectHandle,
+        &'a Objects::CollisionObject,
+        RayIntersection<N>,
+    )>,
+}
+
+impl<'a, 'b, N: RealField, T, BV, Objects> FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects>
+where
+    Objects: CollisionObjectSet<N>,
+    BV: RayCast<N>,
+{
+    /// Creates a new `FirstRayInterferenceVisitor`.
+    #[inline]
+    pub fn new(ray: &'b Ray<N>, solid: bool, handles: &'a DBVTBroadPhase<N, BV, T>, narrow_phase: &'a dyn Fn(T, &'b Ray<N>) -> Option<(
+        Objects::CollisionObjectHandle,
+        &'a Objects::CollisionObject,
+        RayIntersection<N>,
+    )> ) ->
+    FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects> {
+        FirstRayInterferenceVisitor {
+            ray,
+            solid,
+            handles,
+            narrow_phase,
+        }
+    }
+}
+
+
+impl<'a, 'b, N, BV, T, Objects> BestFirstVisitor<N, BroadPhaseProxyHandle, BV> for FirstRayInterferenceVisitor<'a, 'b, N, T, BV, Objects>
+where
+    N: RealField,
+    BV: RayCast<N>,
+    Objects: CollisionObjectSet<N>,
+{
+    type Result = (
+        Objects::CollisionObjectHandle,
+        &'a Objects::CollisionObject,
+        RayIntersection<N>,
+    );
+
+    #[inline]
+    fn visit(
+        &mut self,
+        best_cost_so_far: N,
+        bv: &BV,
+        value: Option<&BroadPhaseProxyHandle>,
+    ) -> BestFirstVisitStatus<N, Self::Result> {
+        let mut res = BestFirstVisitStatus::Stop;
+        if let Some(rough_toi) = bv.toi_with_ray(&Isometry::identity(), self.ray, self.solid) {
+            res = BestFirstVisitStatus::Continue {cost: rough_toi, result: None};
+
+            if rough_toi < best_cost_so_far {
+                if let Some(handle) = value {
+                    if let Some((_, narrow_handle)) = self.handles.proxy(handle) {
+                        if let Some(result) = (self.narrow_phase)(narrow_handle, self.ray) {
+                            res = BestFirstVisitStatus::Continue {cost: result.2.toi, result: Some(result)};
+                        }
+                    }
+                };
+            }
+
+        }
+
+        res
+    }
+}

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -4,14 +4,14 @@ pub use self::aabb_sets_interferences_collector::AABBSetsInterferencesCollector;
 pub use self::bounding_volume_interferences_collector::BoundingVolumeInterferencesCollector;
 pub use self::composite_closest_point_visitor::CompositeClosestPointVisitor;
 pub use self::composite_point_containment_test::CompositePointContainmentTest;
+pub use self::first_ray_interference_visitor::FirstRayInterferenceVisitor;
 pub use self::point_interferences_collector::PointInterferencesCollector;
 pub use self::ray_interferences_collector::RayInterferencesCollector;
-pub use self::first_ray_interference_visitor::FirstRayInterferenceVisitor;
 
 mod aabb_sets_interferences_collector;
 mod bounding_volume_interferences_collector;
 mod composite_closest_point_visitor;
 mod composite_point_containment_test;
+mod first_ray_interference_visitor;
 mod point_interferences_collector;
 mod ray_interferences_collector;
-mod first_ray_interference_visitor;

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -4,7 +4,7 @@ pub use self::aabb_sets_interferences_collector::AABBSetsInterferencesCollector;
 pub use self::bounding_volume_interferences_collector::BoundingVolumeInterferencesCollector;
 pub use self::composite_closest_point_visitor::CompositeClosestPointVisitor;
 pub use self::composite_point_containment_test::CompositePointContainmentTest;
-pub use self::first_ray_interference_visitor::FirstRayInterferenceVisitor;
+pub use self::ray_intersection_cost_fn_visitor::RayIntersectionCostFnVisitor;
 pub use self::point_interferences_collector::PointInterferencesCollector;
 pub use self::ray_interferences_collector::RayInterferencesCollector;
 
@@ -12,6 +12,6 @@ mod aabb_sets_interferences_collector;
 mod bounding_volume_interferences_collector;
 mod composite_closest_point_visitor;
 mod composite_point_containment_test;
-mod first_ray_interference_visitor;
+mod ray_intersection_cost_fn_visitor;
 mod point_interferences_collector;
 mod ray_interferences_collector;

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -6,6 +6,7 @@ pub use self::composite_closest_point_visitor::CompositeClosestPointVisitor;
 pub use self::composite_point_containment_test::CompositePointContainmentTest;
 pub use self::point_interferences_collector::PointInterferencesCollector;
 pub use self::ray_interferences_collector::RayInterferencesCollector;
+pub use self::first_ray_interference_visitor::FirstRayInterferenceVisitor;
 
 mod aabb_sets_interferences_collector;
 mod bounding_volume_interferences_collector;
@@ -13,3 +14,4 @@ mod composite_closest_point_visitor;
 mod composite_point_containment_test;
 mod point_interferences_collector;
 mod ray_interferences_collector;
+mod first_ray_interference_visitor;

--- a/src/query/visitors/mod.rs
+++ b/src/query/visitors/mod.rs
@@ -4,14 +4,14 @@ pub use self::aabb_sets_interferences_collector::AABBSetsInterferencesCollector;
 pub use self::bounding_volume_interferences_collector::BoundingVolumeInterferencesCollector;
 pub use self::composite_closest_point_visitor::CompositeClosestPointVisitor;
 pub use self::composite_point_containment_test::CompositePointContainmentTest;
-pub use self::ray_intersection_cost_fn_visitor::RayIntersectionCostFnVisitor;
 pub use self::point_interferences_collector::PointInterferencesCollector;
 pub use self::ray_interferences_collector::RayInterferencesCollector;
+pub use self::ray_intersection_cost_fn_visitor::RayIntersectionCostFnVisitor;
 
 mod aabb_sets_interferences_collector;
 mod bounding_volume_interferences_collector;
 mod composite_closest_point_visitor;
 mod composite_point_containment_test;
-mod ray_intersection_cost_fn_visitor;
 mod point_interferences_collector;
 mod ray_interferences_collector;
+mod ray_intersection_cost_fn_visitor;

--- a/src/query/visitors/ray_intersection_cost_fn_visitor.rs
+++ b/src/query/visitors/ray_intersection_cost_fn_visitor.rs
@@ -70,15 +70,12 @@ where
 
             // If the node has data then it is a leaf
             if let Some(data_handle) = data {
-
                 // all objects within the tree must be further away than the
                 // bounding volume (TODO: is this true?)
                 if rough_toi < best_cost_so_far {
-
                     // Possibly the best. Look up underlying data of the node...
                     // TODO: Should this be `.expect()`?
                     if let Some((_, leaf_data)) = self.broad_phase.proxy(*data_handle) {
-
                         // and then run the cost function with the nodes data
                         if let Some(result) = (self.cost_fn)(leaf_data.clone(), self.ray) {
                             res = BestFirstVisitStatus::Continue {

--- a/src/query/visitors/ray_intersection_cost_fn_visitor.rs
+++ b/src/query/visitors/ray_intersection_cost_fn_visitor.rs
@@ -70,6 +70,9 @@ where
 
             // If the node has data then it is a leaf
             if let Some(data_handle) = data {
+
+                // all objects within the tree must be further away than the
+                // bounding volume (TODO: is this true?)
                 if rough_toi < best_cost_so_far {
 
                     // Possibly the best. Look up underlying data of the node...
@@ -89,7 +92,7 @@ where
 
             res
         } else {
-            // No intersection
+            // No intersection so we can ignore all children
             BestFirstVisitStatus::Stop
         }
     }


### PR DESCRIPTION
# Summary
This PR adds a new method to the `CollisionWorld` for detecting the first ray intersection with an object.

It creates a new visitor called `RayIntersectionCostFnVisitor` which takes in a cost function and applies it for each leaf node in the BVH using the data contained. This visitor is relatively generic and can be used for other cost functions applied to a `BroadPhase`.

The `.first_intersection_with_ray()` method passes in the equivalent of a narrow phase as the cost function which finds the smallest `toi` in the tree.

# What's left:
- There are a few TODO's left in comments that mainly involve traits being more restrictive than I would like. It should be possible to make them more open in the future without a major interface change so maybe not blocking?
- I would like to add a minimum and maximum to the cost function visitor so that it can ignore the values outside the accepted range. I think this should be added as a new members to the visitor struct with default values applied. A new constructor method could be created to set them. Does this actually work without bloating the API too much?
- How optimal is the implementation here? I did a rough benchmark test using an external repo and it seemed to be slightly more efficient with 100 objects or so but it's hard to quantify.