### PR TITLE
Add a maximum TOI limit to every ray-cast queries.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ jobs:
           command: cargo install -f cargo-web;
       - run:
           name: build ncollide2d
-          command: cargo web build --verbose --target wasm32-unknown-unknown -p ncollide2d;
+          command: cd build/ncollide2d && cargo web build --verbose --target wasm32-unknown-unknown;
       - run:
           name: build ncollide3d
-          command: cargo web build --verbose --target wasm32-unknown-unknown -p ncollide3d;
+          command: cd build/ncollide3d && cargo web build --verbose --target wasm32-unknown-unknown;
   bench-native:
     executor: rust-nightly-executor
     steps:

--- a/build/ncollide2d/examples/first_ray_intersect.rs
+++ b/build/ncollide2d/examples/first_ray_intersect.rs
@@ -43,9 +43,9 @@ fn main() {
     let ray_miss = Ray::<f32>::new(Point2::origin(), -Vector2::x());
 
     let hit = world
-        .first_interference_with_ray(&ray_hit, &collision_group)
+        .first_interference_with_ray(&ray_hit, std::f32::MAX, &collision_group)
         .expect("Hit missed");
-    let miss = world.first_interference_with_ray(&ray_miss, &collision_group);
+    let miss = world.first_interference_with_ray(&ray_miss, std::f32::MAX, &collision_group);
 
     println!("Hit: {:?}", hit.inter);
 

--- a/build/ncollide2d/examples/ray_bvt2d.rs
+++ b/build/ncollide2d/examples/ray_bvt2d.rs
@@ -66,8 +66,10 @@ fn main() {
 
     // We need a new scope here to avoid borrowing issues.
     {
-        let mut visitor_hit = RayInterferencesCollector::new(&ray_hit, &mut collector_hit);
-        let mut visitor_miss = RayInterferencesCollector::new(&ray_miss, &mut collector_miss);
+        let mut visitor_hit =
+            RayInterferencesCollector::new(&ray_hit, std::f64::MAX, &mut collector_hit);
+        let mut visitor_miss =
+            RayInterferencesCollector::new(&ray_miss, std::f64::MAX, &mut collector_miss);
 
         bvt.visit(&mut visitor_hit);
         bvt.visit(&mut visitor_miss);

--- a/build/ncollide2d/examples/solid_ray_cast2d.rs
+++ b/build/ncollide2d/examples/solid_ray_cast2d.rs
@@ -13,7 +13,7 @@ fn main() {
     // Solid cast.
     assert_eq!(
         cuboid
-            .toi_with_ray(&Isometry2::identity(), &ray_inside, true)
+            .toi_with_ray(&Isometry2::identity(), &ray_inside, std::f32::MAX, true)
             .unwrap(),
         0.0
     );
@@ -21,16 +21,16 @@ fn main() {
     // Non-solid cast.
     assert_eq!(
         cuboid
-            .toi_with_ray(&Isometry2::identity(), &ray_inside, false)
+            .toi_with_ray(&Isometry2::identity(), &ray_inside, std::f32::MAX, false)
             .unwrap(),
         2.0
     );
 
     // The other ray does not intersect this shape.
     assert!(cuboid
-        .toi_with_ray(&Isometry2::identity(), &ray_miss, false)
+        .toi_with_ray(&Isometry2::identity(), &ray_miss, std::f32::MAX, false)
         .is_none());
     assert!(cuboid
-        .toi_with_ray(&Isometry2::identity(), &ray_miss, true)
+        .toi_with_ray(&Isometry2::identity(), &ray_miss, std::f32::MAX, true)
         .is_none());
 }

--- a/build/ncollide2d/tests/geometry/ray_cast.rs
+++ b/build/ncollide2d/tests/geometry/ray_cast.rs
@@ -8,7 +8,7 @@ fn issue_178_parallel_raycast() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(2.0, 1.0), Point2::new(2.0, 0.0));
 
-    let cast = seg.toi_with_ray(&m1, &ray, true);
+    let cast = seg.toi_with_ray(&m1, &ray, std::f32::MAX, true);
     assert!(cast.is_none());
 }
 
@@ -18,7 +18,7 @@ fn parallel_raycast() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(2.0, 1.0), Point2::new(2.0, -1.0));
 
-    let cast = seg.toi_with_ray(&m1, &ray, true);
+    let cast = seg.toi_with_ray(&m1, &ray, std::f32::MAX, true);
     assert!(cast.is_none());
 }
 
@@ -28,7 +28,7 @@ fn collinear_raycast_starting_on_segment() {
     let ray = Ray::new(Point2::new(0.0, 0.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.toi_with_ray(&m1, &ray, true);
+    let cast = seg.toi_with_ray(&m1, &ray, std::f32::MAX, true);
     assert_eq!(cast, Some(0.0));
 }
 
@@ -38,7 +38,7 @@ fn collinear_raycast_starting_bellow_segment() {
     let ray = Ray::new(Point2::new(0.0, -2.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.toi_with_ray(&m1, &ray, true);
+    let cast = seg.toi_with_ray(&m1, &ray, std::f32::MAX, true);
     assert_eq!(cast, Some(1.0));
 }
 
@@ -48,7 +48,7 @@ fn collinear_raycast_starting_above_segment() {
     let ray = Ray::new(Point2::new(0.0, 2.0), Vector2::new(0.0, 1.0));
     let seg = Segment::new(Point2::new(0.0, 1.0), Point2::new(0.0, -1.0));
 
-    let cast = seg.toi_with_ray(&m1, &ray, true);
+    let cast = seg.toi_with_ray(&m1, &ray, std::f32::MAX, true);
     assert_eq!(cast, None);
 }
 
@@ -56,14 +56,14 @@ fn collinear_raycast_starting_above_segment() {
 fn perpendicular_raycast_starting_behind_sement() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(-1.0, 0.0), Vector2::new(1.0, 0.0));
-    assert!(segment.intersects_ray(&na::one(), &ray));
+    assert!(segment.intersects_ray(&na::one(), &ray, std::f32::MAX));
 }
 
 #[test]
 fn perpendicular_raycast_starting_in_front_of_sement() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(1.0, 0.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_ray(&na::one(), &ray));
+    assert!(!segment.intersects_ray(&na::one(), &ray, std::f32::MAX));
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn perpendicular_raycast_starting_on_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, 3.0), Vector2::new(1.0, 0.0));
 
-    let cast = segment.toi_with_ray(&na::one(), &ray, true);
+    let cast = segment.toi_with_ray(&na::one(), &ray, std::f32::MAX, true);
     assert_eq!(cast, Some(0.0));
 }
 
@@ -79,14 +79,14 @@ fn perpendicular_raycast_starting_on_segment() {
 fn perpendicular_raycast_starting_above_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, 11.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_ray(&na::one(), &ray));
+    assert!(!segment.intersects_ray(&na::one(), &ray, std::f32::MAX));
 }
 
 #[test]
 fn perpendicular_raycast_starting_bellow_segment() {
     let segment = Segment::new(Point2::new(0.0f32, -10.0), Point2::new(0.0, 10.0));
     let ray = Ray::new(Point2::new(0.0, -11.0), Vector2::new(1.0, 0.0));
-    assert!(!segment.intersects_ray(&na::one(), &ray));
+    assert!(!segment.intersects_ray(&na::one(), &ray, std::f32::MAX));
 }
 
 ///    Ray Target
@@ -116,6 +116,7 @@ fn convexpoly_raycast_fuzz() {
         raycaster.toi_with_ray(
             &Isometry2::identity(),
             &Ray::new(ray_origin, ray_angle.normalize()),
+            std::f64::MAX,
             true,
         )
     };

--- a/build/ncollide3d/benches/query/ray.rs
+++ b/build/ncollide3d/benches/query/ray.rs
@@ -13,13 +13,14 @@ use test::Bencher;
 #[macro_use]
 mod macros;
 
-// FIXME: will the randomness of `solid` affect too much the benchmark?
+// FIXME: will the randomness of `solid` and `max_toi` affect too much the benchmark?
 bench_method!(
     bench_ray_against_ball,
     toi_with_ray,
     b: Ball<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -29,6 +30,7 @@ bench_method!(
     c: Cuboid<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -38,6 +40,7 @@ bench_method!(
     c: Capsule<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -47,6 +50,7 @@ bench_method!(
     c: Cone<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -56,6 +60,7 @@ bench_method!(
     c: Cylinder<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -65,6 +70,7 @@ bench_method!(
     a: AABB<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -74,6 +80,7 @@ bench_method!(
     b: BoundingSphere<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -83,6 +90,7 @@ bench_method!(
     b: Ball<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -92,6 +100,7 @@ bench_method!(
     c: Cuboid<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -101,6 +110,7 @@ bench_method!(
     c: Capsule<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -110,6 +120,7 @@ bench_method!(
     c: Cone<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -119,6 +130,7 @@ bench_method!(
     c: Cylinder<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -128,6 +140,7 @@ bench_method!(
     c: Segment<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -137,6 +150,7 @@ bench_method!(
     c: Triangle<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -146,6 +160,7 @@ bench_method!(
     c: ConvexHull<f32>,
     pos: Isometry3<f32>,
     ray: Ray<f32>,
+    max_toi: f32,
     solid: bool
 );
 
@@ -155,5 +170,6 @@ bench_method_gen!(
     m: TriMesh<f32> = generate_trimesh_around_origin,
     pos: Isometry3<f32> = generate,
     ray: Ray<f32> = generate,
+    max_toi: f32 = generate,
     solid: bool = generate
 );

--- a/build/ncollide3d/examples/getting_started.rs
+++ b/build/ncollide3d/examples/getting_started.rs
@@ -9,5 +9,5 @@ fn main() {
     let cube = Cuboid::new(Vector3::new(1.0f32, 1.0, 1.0));
     let ray = Ray::new(Point3::new(0.0f32, 0.0, -1.0), Vector3::z());
 
-    assert!(cube.intersects_ray(&Isometry3::identity(), &ray));
+    assert!(cube.intersects_ray(&Isometry3::identity(), &ray, std::f32::MAX));
 }

--- a/build/ncollide3d/examples/ray_bvt3d.rs
+++ b/build/ncollide3d/examples/ray_bvt3d.rs
@@ -65,8 +65,10 @@ fn main() {
 
     // We need a new scope here to avoid borrowing issues.
     {
-        let mut visitor_hit = RayInterferencesCollector::new(&ray_hit, &mut collector_hit);
-        let mut visitor_miss = RayInterferencesCollector::new(&ray_miss, &mut collector_miss);
+        let mut visitor_hit =
+            RayInterferencesCollector::new(&ray_hit, std::f64::MAX, &mut collector_hit);
+        let mut visitor_miss =
+            RayInterferencesCollector::new(&ray_miss, std::f64::MAX, &mut collector_miss);
 
         bvt.visit(&mut visitor_hit);
         bvt.visit(&mut visitor_miss);

--- a/build/ncollide3d/examples/solid_ray_cast3d.rs
+++ b/build/ncollide3d/examples/solid_ray_cast3d.rs
@@ -11,26 +11,26 @@ fn main() {
     let ray_miss = Ray::new(Point3::new(2.0, 2.0, 2.0), Vector3::new(1.0, 1.0, 1.0));
 
     // Solid cast.
-    assert!(
+    assert_eq!(
         cuboid
-            .toi_with_ray(&Isometry3::identity(), &ray_inside, true)
-            .unwrap()
-            == 0.0
+            .toi_with_ray(&Isometry3::identity(), &ray_inside, std::f32::MAX, true)
+            .unwrap(),
+        0.0
     );
 
     // Non-solid cast.
-    assert!(
+    assert_eq!(
         cuboid
-            .toi_with_ray(&Isometry3::identity(), &ray_inside, false)
-            .unwrap()
-            == 2.0
+            .toi_with_ray(&Isometry3::identity(), &ray_inside, std::f32::MAX, false)
+            .unwrap(),
+        2.0
     );
 
     // The other ray does not intersect this shape.
     assert!(cuboid
-        .toi_with_ray(&Isometry3::identity(), &ray_miss, false)
+        .toi_with_ray(&Isometry3::identity(), &ray_miss, std::f32::MAX, false)
         .is_none());
     assert!(cuboid
-        .toi_with_ray(&Isometry3::identity(), &ray_miss, true)
+        .toi_with_ray(&Isometry3::identity(), &ray_miss, std::f32::MAX, true)
         .is_none());
 }

--- a/build/ncollide3d/tests/geometry/cuboid_ray_cast.rs
+++ b/build/ncollide3d/tests/geometry/cuboid_ray_cast.rs
@@ -20,7 +20,7 @@ where
         let isometry = Isometry3::from_parts(Translation3::identity(), rotation);
 
         let intersection = shape
-            .toi_and_normal_with_ray(&isometry, &ray, true)
+            .toi_and_normal_with_ray(&isometry, &ray, std::f32::MAX, true)
             .expect(&format!(
                 "Ray {:?} did not hit Shape {} rotated with {:?}",
                 ray, name, rotation
@@ -54,7 +54,7 @@ where
 
         assert!(
             shape
-                .toi_and_normal_with_ray(&isometry, &new_ray, true)
+                .toi_and_normal_with_ray(&isometry, &new_ray, std::f32::MAX, true)
                 .is_none(),
             format!(
                 "Ray {:#?} from outside Shape {} rotated with {:#?} did hit at t={}",
@@ -62,7 +62,7 @@ where
                 name,
                 rotation,
                 shape
-                    .toi_and_normal_with_ray(&isometry, &new_ray, true)
+                    .toi_and_normal_with_ray(&isometry, &new_ray, std::f32::MAX, true)
                     .expect("recurring ray cast produced a different answer")
                     .toi
             )

--- a/build/ncollide3d/tests/geometry/interferences_with_ray.rs
+++ b/build/ncollide3d/tests/geometry/interferences_with_ray.rs
@@ -21,7 +21,7 @@ fn interferences_with_ray() {
 
     let ray = Ray::new(Point3::new(0.0, 0.0, 0.0), Vector3::new(1.0, 1.0, 1.0));
 
-    assert!(ball.toi_with_ray(&iso, &ray, true,).is_some());
+    assert!(ball.toi_with_ray(&iso, &ray, std::f32::MAX, true).is_some());
 
     let shape = ShapeHandle::new(ball);
     world.add(iso, shape.clone(), groups, query, ());
@@ -38,7 +38,7 @@ fn interferences_with_ray() {
         num_collision_objects,
     );
 
-    let interferences = world.interferences_with_ray(&ray, &groups);
+    let interferences = world.interferences_with_ray(&ray, std::f32::MAX, &groups);
     let num_collisions = interferences.into_iter().collect::<Vec<_>>().len();
     assert_eq!(
         num_collisions, 1,

--- a/src/pipeline/broad_phase/broad_phase.rs
+++ b/src/pipeline/broad_phase/broad_phase.rs
@@ -72,14 +72,15 @@ pub trait BroadPhase<N: RealField, BV, T>: Any + Sync + Send {
     fn interferences_with_bounding_volume<'a>(&'a self, bv: &BV, out: &mut Vec<&'a T>);
 
     /// Collects every object which might intersect a given ray.
-    fn interferences_with_ray<'a>(&'a self, ray: &Ray<N>, out: &mut Vec<&'a T>);
+    fn interferences_with_ray<'a>(&'a self, ray: &Ray<N>, max_toi: N, out: &mut Vec<&'a T>);
 
     /// Collects every object which might contain a given point.
     fn interferences_with_point<'a>(&'a self, point: &Point<N>, out: &mut Vec<&'a T>);
 
-    fn interference_cost_fn_with_ray<'a, 'b>(
+    fn first_interference_with_ray<'a, 'b>(
         &'a self,
         ray: &'b Ray<N>,
-        cost_fn: &'a dyn Fn(T, &'b Ray<N>) -> Option<(T, RayIntersection<N>)>,
+        max_toi: N,
+        cost_fn: &'a dyn Fn(T, &'b Ray<N>, N) -> Option<(T, RayIntersection<N>)>,
     ) -> Option<(T, RayIntersection<N>)>;
 }

--- a/src/pipeline/broad_phase/dbvt_broad_phase.rs
+++ b/src/pipeline/broad_phase/dbvt_broad_phase.rs
@@ -399,11 +399,11 @@ where
         }
     }
 
-    fn interferences_with_ray<'a>(&'a self, ray: &Ray<N>, out: &mut Vec<&'a T>) {
+    fn interferences_with_ray<'a>(&'a self, ray: &Ray<N>, max_toi: N, out: &mut Vec<&'a T>) {
         let mut collector = Vec::new();
 
         {
-            let mut visitor = RayInterferencesCollector::new(ray, &mut collector);
+            let mut visitor = RayInterferencesCollector::new(ray, max_toi, &mut collector);
 
             self.tree.visit(&mut visitor);
             self.stree.visit(&mut visitor);
@@ -429,15 +429,16 @@ where
         }
     }
 
-    /// Returns the first object that interferes with a ray
-    fn interference_cost_fn_with_ray<'a, 'b>(
+    /// Returns the first object that interferes with a ray.
+    fn first_interference_with_ray<'a, 'b>(
         &'a self,
         ray: &'b Ray<N>,
-        cost_fn: &'a dyn Fn(T, &'b Ray<N>) -> Option<(T, RayIntersection<N>)>,
+        max_toi: N,
+        cost_fn: &'a dyn Fn(T, &'b Ray<N>, N) -> Option<(T, RayIntersection<N>)>,
     ) -> Option<(T, RayIntersection<N>)> {
         let res = {
             let mut visitor =
-                RayIntersectionCostFnVisitor::<'a, 'b, N, T, BV>::new(ray, self, cost_fn);
+                RayIntersectionCostFnVisitor::<'a, 'b, N, T, BV>::new(ray, max_toi, self, cost_fn);
 
             let dynamic_hit = self.tree.best_first_search(&mut visitor);
             let static_hit = self.stree.best_first_search(&mut visitor);

--- a/src/pipeline/glue/query.rs
+++ b/src/pipeline/glue/query.rs
@@ -58,9 +58,12 @@ where
         while let Some(handle) = self.handles.next() {
             if let Some(co) = self.objects.collision_object(*handle) {
                 if co.collision_groups().can_interact_with_groups(self.groups) {
-                    let inter = co
-                        .shape()
-                        .toi_and_normal_with_ray(&co.position(), self.ray, self.max_toi, true);
+                    let inter = co.shape().toi_and_normal_with_ray(
+                        &co.position(),
+                        self.ray,
+                        self.max_toi,
+                        true,
+                    );
 
                     if let Some(inter) = inter {
                         return Some((*handle, co, inter));

--- a/src/pipeline/glue/query.rs
+++ b/src/pipeline/glue/query.rs
@@ -14,6 +14,7 @@ pub fn interferences_with_ray<'a, 'b, N, Objects>(
     objects: &'a Objects,
     broad_phase: &'a (impl BroadPhase<N, AABB<N>, Objects::CollisionObjectHandle> + ?Sized),
     ray: &'b Ray<N>,
+    max_toi: N,
     groups: &'b CollisionGroups,
 ) -> InterferencesWithRay<'a, 'b, N, Objects>
 where
@@ -21,10 +22,11 @@ where
     Objects: CollisionObjectSet<N>,
 {
     let mut handles = Vec::new();
-    broad_phase.interferences_with_ray(ray, &mut handles);
+    broad_phase.interferences_with_ray(ray, max_toi, &mut handles);
 
     InterferencesWithRay {
         ray,
+        max_toi,
         groups,
         objects,
         handles: handles.into_iter(),
@@ -34,6 +36,7 @@ where
 /// Iterator through all the objects on the world that intersect a specific ray.
 pub struct InterferencesWithRay<'a, 'b, N: RealField, Objects: CollisionObjectSet<N>> {
     ray: &'b Ray<N>,
+    max_toi: N,
     objects: &'a Objects,
     groups: &'b CollisionGroups,
     handles: IntoIter<&'a Objects::CollisionObjectHandle>,
@@ -57,7 +60,7 @@ where
                 if co.collision_groups().can_interact_with_groups(self.groups) {
                     let inter = co
                         .shape()
-                        .toi_and_normal_with_ray(&co.position(), self.ray, true);
+                        .toi_and_normal_with_ray(&co.position(), self.ray, self.max_toi, true);
 
                     if let Some(inter) = inter {
                         return Some((*handle, co, inter));
@@ -195,31 +198,24 @@ pub fn first_interference_with_ray<'a, 'b, N: RealField, Objects: CollisionObjec
     objects: &'a Objects,
     broad_phase: &'a (impl BroadPhase<N, AABB<N>, Objects::CollisionObjectHandle> + ?Sized),
     ray: &'b Ray<N>,
+    max_toi: N,
     groups: &'b CollisionGroups,
 ) -> Option<FirstInterferenceWithRay<'a, N, Objects>> {
     // Narrow phase
-    let narrow_phase = move |handle: Objects::CollisionObjectHandle, ray: &Ray<N>| {
-        if let Some(co) = objects.collision_object(handle) {
-            if co.collision_groups().can_interact_with_groups(groups) {
-                let inter = co
-                    .shape()
-                    .toi_and_normal_with_ray(&co.position(), ray, true);
+    let narrow_phase = move |handle: Objects::CollisionObjectHandle, ray: &Ray<N>, max_toi: N| {
+        let co = objects.collision_object(handle)?;
+        if co.collision_groups().can_interact_with_groups(groups) {
+            let inter = co
+                .shape()
+                .toi_and_normal_with_ray(&co.position(), ray, max_toi, true);
 
-                if let Some(inter) = inter {
-                    return Some((handle, inter));
-                }
-            }
+            inter.map(|inter| (handle, inter))
+        } else {
+            None
         }
-        None
     };
 
-    let mut res = None;
-
-    if let Some((handle, inter)) = broad_phase.interference_cost_fn_with_ray(ray, &narrow_phase) {
-        if let Some(co) = objects.collision_object(handle) {
-            res = Some(FirstInterferenceWithRay { handle, co, inter });
-        }
-    }
-
-    res
+    let (handle, inter) = broad_phase.first_interference_with_ray(ray, max_toi, &narrow_phase)?;
+    let co = objects.collision_object(handle)?;
+    Some(FirstInterferenceWithRay { handle, co, inter })
 }

--- a/src/pipeline/world.rs
+++ b/src/pipeline/world.rs
@@ -339,19 +339,21 @@ impl<N: RealField, T> CollisionWorld<N, T> {
     pub fn interferences_with_ray<'a, 'b>(
         &'a self,
         ray: &'b Ray<N>,
+        max_toi: N,
         groups: &'b CollisionGroups,
     ) -> InterferencesWithRay<'a, 'b, N, CollisionObjectSlab<N, T>> {
-        glue::interferences_with_ray(&self.objects, &*self.broad_phase, ray, groups)
+        glue::interferences_with_ray(&self.objects, &*self.broad_phase, ray, max_toi, groups)
     }
 
-    /// Computes the interferences between every rigid bodies on this world and a ray.
+    /// Computes the first interference with `ray` and
     #[inline]
     pub fn first_interference_with_ray<'a, 'b>(
         &'a self,
         ray: &'b Ray<N>,
+        max_toi: N,
         groups: &'b CollisionGroups,
     ) -> Option<FirstInterferenceWithRay<'a, N, CollisionObjectSlab<N, T>>> {
-        glue::first_interference_with_ray(&self.objects, &*self.broad_phase, ray, groups)
+        glue::first_interference_with_ray(&self.objects, &*self.broad_phase, ray, max_toi, groups)
     }
 
     /// Computes the interferences between every rigid bodies of a given broad phase, and a point.

--- a/src/query/algorithms/epa2.rs
+++ b/src/query/algorithms/epa2.rs
@@ -290,7 +290,7 @@ impl<N: RealField> EPA<N> {
                 Face::new(&self.vertices, pts2),
             ];
 
-            for f in new_faces.into_iter() {
+            for f in new_faces.iter() {
                 if f.1 {
                     let dist = f.0.normal.dot(&f.0.proj.coords);
                     if dist < curr_dist {

--- a/src/query/point/point_query.rs
+++ b/src/query/point/point_query.rs
@@ -25,7 +25,6 @@ impl<N: RealField> PointProjection<N> {
 /// Trait of objects that can be tested for point inclusion and projection.
 pub trait PointQuery<N: RealField> {
     /// Projects a point on `self` transformed by `m`.
-    #[inline]
     fn project_point(&self, m: &Isometry<N>, pt: &Point<N>, solid: bool) -> PointProjection<N>;
 
     /// Computes the minimal distance between a point and `self` transformed by `m`.
@@ -43,7 +42,6 @@ pub trait PointQuery<N: RealField> {
 
     /// Projects a point on the boundary of `self` transformed by `m` and retuns the id of the
     /// feature the point was projected on.
-    #[inline]
     fn project_point_with_feature(
         &self,
         m: &Isometry<N>,
@@ -81,7 +79,6 @@ pub trait PointQueryWithLocation<N: RealField> {
     type Location;
 
     /// Projects a point on `self` transformed by `m`.
-    #[inline]
     fn project_point_with_location(
         &self,
         m: &Isometry<N>,

--- a/src/query/ray/ray.rs
+++ b/src/query/ray/ray.rs
@@ -124,17 +124,17 @@ impl<N: RealField> RayIntersection<N> {
 /// Traits of objects which can be transformed and tested for intersection with a ray.
 pub trait RayCast<N: RealField> {
     /// Computes the time of impact between this transform shape and a ray.
-    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, solid: bool) -> Option<N> {
-        self.toi_and_normal_with_ray(m, ray, solid)
+    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
+        self.toi_and_normal_with_ray(m, ray, max_toi, solid)
             .map(|inter| inter.toi)
     }
 
     /// Computes the time of impact, and normal between this transformed shape and a ray.
-    #[inline]
     fn toi_and_normal_with_ray(
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>>;
 
@@ -146,14 +146,15 @@ pub trait RayCast<N: RealField> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
-        self.toi_and_normal_with_ray(m, ray, solid)
+        self.toi_and_normal_with_ray(m, ray, max_toi, solid)
     }
 
     /// Tests whether a ray intersects this transformed shape.
     #[inline]
-    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>) -> bool {
-        self.toi_with_ray(m, ray, true).is_some()
+    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N) -> bool {
+        self.toi_with_ray(m, ray, max_toi, true).is_some()
     }
 }

--- a/src/query/ray/ray_ball.rs
+++ b/src/query/ray/ray_ball.rs
@@ -30,7 +30,8 @@ impl<N: RealField> RayCast<N> for Ball<N> {
             ray,
             solid,
         )
-        .1.filter(|toi| *toi <= max_toi)
+        .1
+        .filter(|toi| *toi <= max_toi)
     }
 
     #[inline]
@@ -47,7 +48,8 @@ impl<N: RealField> RayCast<N> for Ball<N> {
             ray,
             solid,
         )
-        .1.filter(|int| int.toi <= max_toi)
+        .1
+        .filter(|int| int.toi <= max_toi)
     }
 
     #[cfg(feature = "dim3")]
@@ -64,16 +66,16 @@ impl<N: RealField> RayCast<N> for Ball<N> {
         inter = inter.filter(|toi| *toi <= max_toi);
 
         inter.map(|n| {
-                let pos = ray.origin + ray.dir * n - center;
-                let normal = pos.normalize();
-                let uv = ball_uv(&normal);
+            let pos = ray.origin + ray.dir * n - center;
+            let normal = pos.normalize();
+            let uv = ball_uv(&normal);
 
-                RayIntersection::new_with_uvs(
-                    n,
-                    if inside { -normal } else { normal },
-                    FeatureId::Face(0),
-                    Some(uv),
-                )
+            RayIntersection::new_with_uvs(
+                n,
+                if inside { -normal } else { normal },
+                FeatureId::Face(0),
+                Some(uv),
+            )
         })
     }
 }

--- a/src/query/ray/ray_bounding_sphere.rs
+++ b/src/query/ray/ray_bounding_sphere.rs
@@ -6,10 +6,10 @@ use na::RealField;
 
 impl<N: RealField> RayCast<N> for BoundingSphere<N> {
     #[inline]
-    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, solid: bool) -> Option<N> {
+    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
         let centered_ray = ray.translate_by(-(m * self.center()).coords);
 
-        Ball::new(self.radius()).toi_with_ray(m, &centered_ray, solid)
+        Ball::new(self.radius()).toi_with_ray(m, &centered_ray, max_toi, solid)
     }
 
     #[inline]
@@ -17,6 +17,7 @@ impl<N: RealField> RayCast<N> for BoundingSphere<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let centered_ray = ray.translate_by(-(m * self.center()).coords);
@@ -24,6 +25,7 @@ impl<N: RealField> RayCast<N> for BoundingSphere<N> {
         Ball::new(self.radius()).toi_and_normal_with_ray(
             &Isometry::identity(),
             &centered_ray,
+            max_toi,
             solid,
         )
     }
@@ -34,6 +36,7 @@ impl<N: RealField> RayCast<N> for BoundingSphere<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let centered_ray = ray.translate_by(-(m * self.center()).coords);
@@ -41,14 +44,15 @@ impl<N: RealField> RayCast<N> for BoundingSphere<N> {
         Ball::new(self.radius()).toi_and_normal_and_uv_with_ray(
             &Isometry::identity(),
             &centered_ray,
+            max_toi,
             solid,
         )
     }
 
     #[inline]
-    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>) -> bool {
+    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N) -> bool {
         let centered_ray = ray.translate_by(-(m * self.center()).coords);
 
-        Ball::new(self.radius()).intersects_ray(&Isometry::identity(), &centered_ray)
+        Ball::new(self.radius()).intersects_ray(&Isometry::identity(), &centered_ray, max_toi)
     }
 }

--- a/src/query/ray/ray_compound.rs
+++ b/src/query/ray/ray_compound.rs
@@ -77,7 +77,10 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for CompoundRayToiVis
             if let Some(b) = data {
                 if toi < best {
                     let elt = &self.compound.shapes()[*b];
-                    if let Some(toi) = elt.1.toi_with_ray(&elt.0, self.ray, self.max_toi, self.solid) {
+                    if let Some(toi) =
+                        elt.1
+                            .toi_with_ray(&elt.0, self.ray, self.max_toi, self.solid)
+                    {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi,
                             result: Some(toi),
@@ -121,7 +124,10 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
             if let Some(b) = data {
                 if toi < best {
                     let elt = &self.compound.shapes()[*b];
-                    if let Some(toi) = elt.1.toi_and_normal_with_ray(&elt.0, self.ray, self.max_toi, self.solid) {
+                    if let Some(toi) =
+                        elt.1
+                            .toi_and_normal_with_ray(&elt.0, self.ray, self.max_toi, self.solid)
+                    {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi.toi,
                             result: Some(toi),

--- a/src/query/ray/ray_cuboid.rs
+++ b/src/query/ray/ray_cuboid.rs
@@ -6,10 +6,10 @@ use na::RealField;
 
 impl<N: RealField> RayCast<N> for Cuboid<N> {
     #[inline]
-    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, solid: bool) -> Option<N> {
+    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
         let dl = Point::from(-*self.half_extents());
         let ur = Point::from(*self.half_extents());
-        AABB::new(dl, ur).toi_with_ray(m, ray, solid)
+        AABB::new(dl, ur).toi_with_ray(m, ray, max_toi, solid)
     }
 
     #[inline]
@@ -17,11 +17,12 @@ impl<N: RealField> RayCast<N> for Cuboid<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let dl = Point::from(-*self.half_extents());
         let ur = Point::from(*self.half_extents());
-        AABB::new(dl, ur).toi_and_normal_with_ray(m, ray, solid)
+        AABB::new(dl, ur).toi_and_normal_with_ray(m, ray, max_toi, solid)
     }
 
     #[cfg(feature = "dim3")]
@@ -30,10 +31,11 @@ impl<N: RealField> RayCast<N> for Cuboid<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let dl = Point::from(-*self.half_extents());
         let ur = Point::from(*self.half_extents());
-        AABB::new(dl, ur).toi_and_normal_and_uv_with_ray(m, ray, solid)
+        AABB::new(dl, ur).toi_and_normal_and_uv_with_ray(m, ray, max_toi, solid)
     }
 }

--- a/src/query/ray/ray_plane.rs
+++ b/src/query/ray/ray_plane.rs
@@ -44,6 +44,7 @@ impl<N: RealField> RayCast<N> for Plane<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         let ls_ray = ray.inverse_transform_by(m);
@@ -63,7 +64,7 @@ impl<N: RealField> RayCast<N> for Plane<N> {
 
         let t = dot_normal_dpos / self.normal().dot(&ls_ray.dir);
 
-        if t >= na::zero() {
+        if t >= na::zero() && t <= max_toi {
             let n = if dot_normal_dpos > na::zero() {
                 -*self.normal()
             } else {

--- a/src/query/ray/ray_polyline.rs
+++ b/src/query/ray/ray_polyline.rs
@@ -79,7 +79,9 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for PolylineRayToiVis
                 if toi < best {
                     // FIXME: optimize this by not using Isometry identity.
                     let segment = self.polyline.segment_at(*b);
-                    if let Some(toi) = segment.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true) {
+                    if let Some(toi) =
+                        segment.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
+                    {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi,
                             result: Some(toi),
@@ -123,9 +125,12 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
                 if toi < best {
                     // FIXME: optimize this by not using Isometry identity.
                     let segment = self.polyline.segment_at(*b);
-                    if let Some(toi) =
-                        segment.toi_and_normal_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
-                    {
+                    if let Some(toi) = segment.toi_and_normal_with_ray(
+                        &Isometry::identity(),
+                        self.ray,
+                        self.max_toi,
+                        true,
+                    ) {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi.toi,
                             result: Some((*b, toi)),

--- a/src/query/ray/ray_polyline.rs
+++ b/src/query/ray/ray_polyline.rs
@@ -7,12 +7,13 @@ use na::RealField;
 
 impl<N: RealField> RayCast<N> for Polyline<N> {
     #[inline]
-    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, _: bool) -> Option<N> {
+    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, _: bool) -> Option<N> {
         let ls_ray = ray.inverse_transform_by(m);
 
         let mut visitor = PolylineRayToiVisitor {
             polyline: self,
             ray: &ls_ray,
+            max_toi,
         };
 
         self.bvt().best_first_search(&mut visitor).map(|res| res.1)
@@ -23,6 +24,7 @@ impl<N: RealField> RayCast<N> for Polyline<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         _: bool,
     ) -> Option<RayIntersection<N>> {
         let ls_ray = ray.inverse_transform_by(m);
@@ -30,6 +32,7 @@ impl<N: RealField> RayCast<N> for Polyline<N> {
         let mut visitor = PolylineRayToiAndNormalVisitor {
             polyline: self,
             ray: &ls_ray,
+            max_toi,
         };
 
         self.bvt()
@@ -53,6 +56,7 @@ impl<N: RealField> RayCast<N> for Polyline<N> {
 struct PolylineRayToiVisitor<'a, N: 'a + RealField> {
     polyline: &'a Polyline<N>,
     ray: &'a Ray<N>,
+    max_toi: N,
 }
 
 impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for PolylineRayToiVisitor<'a, N> {
@@ -65,7 +69,7 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for PolylineRayToiVis
         aabb: &AABB<N>,
         data: Option<&usize>,
     ) -> BestFirstVisitStatus<N, Self::Result> {
-        if let Some(toi) = aabb.toi_with_ray(&Isometry::identity(), self.ray, true) {
+        if let Some(toi) = aabb.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true) {
             let mut res = BestFirstVisitStatus::Continue {
                 cost: toi,
                 result: None,
@@ -75,7 +79,7 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for PolylineRayToiVis
                 if toi < best {
                     // FIXME: optimize this by not using Isometry identity.
                     let segment = self.polyline.segment_at(*b);
-                    if let Some(toi) = segment.toi_with_ray(&Isometry::identity(), self.ray, true) {
+                    if let Some(toi) = segment.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true) {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi,
                             result: Some(toi),
@@ -94,6 +98,7 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for PolylineRayToiVis
 struct PolylineRayToiAndNormalVisitor<'a, N: 'a + RealField> {
     polyline: &'a Polyline<N>,
     ray: &'a Ray<N>,
+    max_toi: N,
 }
 
 impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
@@ -108,7 +113,7 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
         aabb: &AABB<N>,
         data: Option<&usize>,
     ) -> BestFirstVisitStatus<N, Self::Result> {
-        if let Some(toi) = aabb.toi_with_ray(&Isometry::identity(), self.ray, true) {
+        if let Some(toi) = aabb.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true) {
             let mut res = BestFirstVisitStatus::Continue {
                 cost: toi,
                 result: None,
@@ -119,7 +124,7 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
                     // FIXME: optimize this by not using Isometry identity.
                     let segment = self.polyline.segment_at(*b);
                     if let Some(toi) =
-                        segment.toi_and_normal_with_ray(&Isometry::identity(), self.ray, true)
+                        segment.toi_and_normal_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
                     {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi.toi,

--- a/src/query/ray/ray_shape.rs
+++ b/src/query/ray/ray_shape.rs
@@ -5,10 +5,10 @@ use na::RealField;
 
 impl<N: RealField> RayCast<N> for dyn Shape<N> {
     #[inline]
-    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, solid: bool) -> Option<N> {
+    fn toi_with_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N, solid: bool) -> Option<N> {
         self.as_ray_cast()
             .expect("No RayCast implementation for the underlying shape.")
-            .toi_with_ray(m, ray, solid)
+            .toi_with_ray(m, ray, max_toi, solid)
     }
 
     #[inline]
@@ -16,11 +16,12 @@ impl<N: RealField> RayCast<N> for dyn Shape<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         self.as_ray_cast()
             .expect("No RayCast implementation for the underlying shape.")
-            .toi_and_normal_with_ray(m, ray, solid)
+            .toi_and_normal_with_ray(m, ray, max_toi, solid)
     }
 
     #[cfg(feature = "dim3")]
@@ -29,17 +30,18 @@ impl<N: RealField> RayCast<N> for dyn Shape<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         self.as_ray_cast()
             .expect("No RayCast implementation for the underlying shape.")
-            .toi_and_normal_and_uv_with_ray(m, ray, solid)
+            .toi_and_normal_and_uv_with_ray(m, ray, max_toi, solid)
     }
 
     #[inline]
-    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>) -> bool {
+    fn intersects_ray(&self, m: &Isometry<N>, ray: &Ray<N>, max_toi: N) -> bool {
         self.as_ray_cast()
             .expect("No RayCast implementation for the underlying shape.")
-            .intersects_ray(m, ray)
+            .intersects_ray(m, ray, max_toi)
     }
 }

--- a/src/query/ray/ray_triangle.rs
+++ b/src/query/ray/ray_triangle.rs
@@ -10,15 +10,18 @@ impl<N: RealField> RayCast<N> for Triangle<N> {
         &self,
         m: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         _: bool,
     ) -> Option<RayIntersection<N>> {
         let ls_ray = ray.inverse_transform_by(m);
-        let res = ray_intersection_with_triangle(self.a(), self.b(), self.c(), &ls_ray);
+        let mut inter = ray_intersection_with_triangle(self.a(), self.b(), self.c(), &ls_ray)?.0;
 
-        res.map(|(mut r, _)| {
-            r.normal = m * r.normal;
-            r
-        })
+        if inter.toi <= max_toi {
+            inter.normal = m * inter.normal;
+            Some(inter)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/query/ray/ray_trimesh.rs
+++ b/src/query/ray/ray_trimesh.rs
@@ -123,7 +123,8 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>> for TriMeshRayToiVisi
                 if toi < best {
                     // FIXME: optimize this by not using Isometry identity.
                     let triangle = self.mesh.triangle_at(*b);
-                    if let Some(toi) = triangle.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
+                    if let Some(toi) =
+                        triangle.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
                     {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi,
@@ -168,9 +169,12 @@ impl<'a, N: RealField> BestFirstVisitor<N, usize, AABB<N>>
                 if toi < best {
                     // FIXME: optimize this by not using Isometry identity.
                     let triangle = self.mesh.triangle_at(*b);
-                    if let Some(toi) =
-                        triangle.toi_and_normal_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
-                    {
+                    if let Some(toi) = triangle.toi_and_normal_with_ray(
+                        &Isometry::identity(),
+                        self.ray,
+                        self.max_toi,
+                        true,
+                    ) {
                         res = BestFirstVisitStatus::Continue {
                             cost: toi.toi,
                             result: Some((*b, toi)),

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -127,7 +127,7 @@ where
         );
 
         // Compute the TOI.
-        if let Some(toi) = msum.toi_with_ray(&Isometry::identity(), &self.ray, true) {
+        if let Some(toi) = msum.toi_with_ray(&Isometry::identity(), &self.ray, self.max_toi, true) {
             if toi > self.max_toi {
                 return BestFirstVisitStatus::Stop;
             }

--- a/src/query/time_of_impact/time_of_impact_plane_support_map.rs
+++ b/src/query/time_of_impact/time_of_impact_plane_support_map.rs
@@ -28,7 +28,7 @@ where
     let closest_point = support_point - *plane_normal * target_distance;
     let ray = Ray::new(closest_point, vel);
 
-    if let Some(toi) = plane.toi_with_ray(mplane, &ray, true) {
+    if let Some(toi) = plane.toi_with_ray(mplane, &ray, max_toi, true) {
         if toi > max_toi {
             return None;
         }

--- a/src/query/visitors/ray_interferences_collector.rs
+++ b/src/query/visitors/ray_interferences_collector.rs
@@ -16,7 +16,11 @@ pub struct RayInterferencesCollector<'a, N: 'a + RealField, T: 'a> {
 impl<'a, N: RealField, T> RayInterferencesCollector<'a, N, T> {
     /// Creates a new `RayInterferencesCollector`.
     #[inline]
-    pub fn new(ray: &'a Ray<N>, max_toi: N, buffer: &'a mut Vec<T>) -> RayInterferencesCollector<'a, N, T> {
+    pub fn new(
+        ray: &'a Ray<N>,
+        max_toi: N,
+        buffer: &'a mut Vec<T>,
+    ) -> RayInterferencesCollector<'a, N, T> {
         RayInterferencesCollector {
             ray,
             max_toi,

--- a/src/query/visitors/ray_interferences_collector.rs
+++ b/src/query/visitors/ray_interferences_collector.rs
@@ -7,6 +7,8 @@ use na::RealField;
 pub struct RayInterferencesCollector<'a, N: 'a + RealField, T: 'a> {
     /// Ray to be tested.
     pub ray: &'a Ray<N>,
+    /// The maximum allowed time of impact.
+    pub max_toi: N,
     /// The data contained by the nodes which bounding volume intersects `self.ray`.
     pub collector: &'a mut Vec<T>,
 }
@@ -14,9 +16,10 @@ pub struct RayInterferencesCollector<'a, N: 'a + RealField, T: 'a> {
 impl<'a, N: RealField, T> RayInterferencesCollector<'a, N, T> {
     /// Creates a new `RayInterferencesCollector`.
     #[inline]
-    pub fn new(ray: &'a Ray<N>, buffer: &'a mut Vec<T>) -> RayInterferencesCollector<'a, N, T> {
+    pub fn new(ray: &'a Ray<N>, max_toi: N, buffer: &'a mut Vec<T>) -> RayInterferencesCollector<'a, N, T> {
         RayInterferencesCollector {
-            ray: ray,
+            ray,
+            max_toi,
             collector: buffer,
         }
     }
@@ -30,7 +33,7 @@ where
 {
     #[inline]
     fn visit(&mut self, bv: &BV, t: Option<&T>) -> VisitStatus {
-        if bv.intersects_ray(&Isometry::identity(), self.ray) {
+        if bv.intersects_ray(&Isometry::identity(), self.ray, self.max_toi) {
             if let Some(t) = t {
                 self.collector.push(t.clone())
             }

--- a/src/query/visitors/ray_intersection_cost_fn_visitor.rs
+++ b/src/query/visitors/ray_intersection_cost_fn_visitor.rs
@@ -67,7 +67,9 @@ where
         bv: &BV,
         data: Option<&BroadPhaseProxyHandle>,
     ) -> BestFirstVisitStatus<N, Self::Result> {
-        if let Some(rough_toi) = bv.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true) {
+        if let Some(rough_toi) =
+            bv.toi_with_ray(&Isometry::identity(), self.ray, self.max_toi, true)
+        {
             let mut res = BestFirstVisitStatus::Continue {
                 cost: rough_toi,
                 result: None,
@@ -82,7 +84,9 @@ where
                     // TODO: Should this be `.expect()`?
                     if let Some((_, leaf_data)) = self.broad_phase.proxy(*data_handle) {
                         // and then run the cost function with the nodes data
-                        if let Some(result) = (self.cost_fn)(leaf_data.clone(), self.ray, self.max_toi) {
+                        if let Some(result) =
+                            (self.cost_fn)(leaf_data.clone(), self.ray, self.max_toi)
+                        {
                             res = BestFirstVisitStatus::Continue {
                                 cost: result.1.toi,
                                 result: Some(result),

--- a/src/shape/shape.rs
+++ b/src/shape/shape.rs
@@ -24,7 +24,6 @@ impl<N: RealField, T: 'static + Shape<N> + Clone> ShapeClone<N> for T {
 /// This allows dynamic inspection of the shape capabilities.
 pub trait Shape<N: RealField>: Send + Sync + Downcast + ShapeClone<N> {
     /// The AABB of `self` transformed by `m`.
-    #[inline]
     fn aabb(&self, m: &Isometry<N>) -> AABB<N>;
 
     /// The AABB of `self`.
@@ -50,7 +49,6 @@ pub trait Shape<N: RealField>: Send + Sync + Downcast + ShapeClone<N> {
     /// Check if if the feature `_feature` of the `i-th` subshape of `self` transformed by `m` has a tangent
     /// cone that contains `dir` at the point `pt`.
     // NOTE: for the moment, we assume the tangent cone is the same for the whole feature.
-    #[inline]
     fn tangent_cone_contains_dir(
         &self,
         _feature: FeatureId,

--- a/src/transformation/hacd.rs
+++ b/src/transformation/hacd.rs
@@ -484,6 +484,7 @@ impl<N: RealField> DualGraphEdge<N> {
                 match chull.toi_with_ray(
                     &Isometry::identity(),
                     &Ray::new(outside_point, -ray.dir),
+                    N::max_value(),
                     true,
                 ) {
                     None => ancestors.push(VertexWithConcavity::new(id, na::zero())),
@@ -552,7 +553,7 @@ impl<N: RealField> DualGraphEdge<N> {
 
                     // We determine if the point is inside of the convex hull or not.
                     // XXX: use a point-in-implicit test instead of a ray-cast!
-                    match chull.toi_with_ray(&Isometry::identity(), ray, true) {
+                    match chull.toi_with_ray(&Isometry::identity(), ray, N::max_value(), true) {
                         None => continue,
                         Some(inter) => {
                             if inter.is_zero() {
@@ -799,6 +800,7 @@ impl<'a, N: RealField> RayCast<N> for ConvexPair<'a, N> {
         &self,
         id: &Isometry<N>,
         ray: &Ray<N>,
+        max_toi: N,
         solid: bool,
     ) -> Option<RayIntersection<N>> {
         query::ray_intersection_with_support_map_with_params(
@@ -806,6 +808,7 @@ impl<'a, N: RealField> RayCast<N> for ConvexPair<'a, N> {
             self,
             &mut VoronoiSimplex::new(),
             ray,
+            max_toi,
             solid,
         )
     }


### PR DESCRIPTION
This is a breaking changes that adds a `max_toi` parameter to every ray-cast queries. This will cause ray-cast queries to return `None` if the time of impact of the ray with the queried shape is greater than `max_toi`.

In other words, if the first hit of the ray with the shape is further than `ray.orig + ray.dir * max_toi`, then `None` is returned.

This PR also fixes the CI build for WASM.