### PR TITLE
Comment & clean up best_first_search, add testcase

### DIFF
--- a/build/ncollide3d/tests/geometry/first_interference_with_ray.rs
+++ b/build/ncollide3d/tests/geometry/first_interference_with_ray.rs
@@ -1,0 +1,76 @@
+use std::f32;
+
+use na::{Isometry3, Point3, Translation3, UnitQuaternion, Vector3};
+use ncollide3d::{
+    pipeline::{CollisionGroups, CollisionWorld, GeometricQueryType},
+    query::{Ray, RayCast},
+    shape::{Ball, ShapeHandle},
+};
+
+#[test]
+fn first_interference_with_ray() {
+    let mut world = CollisionWorld::new(0.01);
+
+    let ball = Ball::new(1.0f32);
+    let groups = CollisionGroups::new();
+    let query = GeometricQueryType::Contacts(0.0, 0.0);
+
+    // obj1
+    let tra = Translation3::new(1.0, 1.0, 0.0);
+    let rot = UnitQuaternion::from_scaled_axis(Vector3::y() * f32::consts::PI);
+    let iso1 = Isometry3::from_parts(tra, rot);
+
+    // obj2
+    let tra = Translation3::new(10.0, 11.8, 0.0);
+    let rot = UnitQuaternion::from_scaled_axis(Vector3::y() * f32::consts::PI);
+    let iso2 = Isometry3::from_parts(tra, rot);
+
+    let ray = Ray::new(
+        Point3::new(0.0, 1.8, 0.0),
+        Vector3::new(1.0, 1.0, 0.0).normalize(),
+    );
+
+    // Ray misses first ball and hits second
+    assert!(ball
+        .toi_with_ray(&iso1, &ray, std::f32::MAX, true)
+        .is_none());
+    assert!(ball
+        .toi_with_ray(&iso2, &ray, std::f32::MAX, true)
+        .is_some());
+    let toi_ball = ball.toi_with_ray(&iso2, &ray, std::f32::MAX, true).unwrap();
+
+    let shape = ShapeHandle::new(ball);
+    world.add(iso1, shape.clone(), groups, query, ());
+    world.add(iso2, shape.clone(), groups, query, ());
+    world.update();
+
+    // Check we've 2 objects in the world
+    let num_collision_objects = world
+        .collision_objects()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .len();
+    assert_eq!(
+        num_collision_objects, 2,
+        "Expected 2 collision objects, got {}",
+        num_collision_objects,
+    );
+
+    // Should have 1 intersection with ray.
+    let interferences = world.interferences_with_ray(&ray, std::f32::MAX, &groups);
+    let num_collisions = interferences.into_iter().collect::<Vec<_>>().len();
+    assert_eq!(
+        num_collisions, 1,
+        "Expected 1 collision, got {}",
+        num_collisions,
+    );
+
+    let first_interference = world.first_interference_with_ray(&ray, std::f32::MAX, &groups);
+    let toi = first_interference.unwrap().inter.toi;
+
+    // toi should be the same as first ball.
+    assert!(
+        (toi - toi_ball).abs() < 0.0001,
+        "Ray collision with unexpected object",
+    );
+}

--- a/build/ncollide3d/tests/geometry/mod.rs
+++ b/build/ncollide3d/tests/geometry/mod.rs
@@ -4,6 +4,7 @@ mod contact;
 mod cuboid_ray_cast;
 mod cylinder_cuboid_contact;
 mod epa3;
+mod first_interference_with_ray;
 mod interferences_with_ray;
 mod still_objects_toi;
 mod time_of_impact3;

--- a/src/partitioning/bvh.rs
+++ b/src/partitioning/bvh.rs
@@ -104,6 +104,7 @@ pub trait BVH<T, BV> {
         BFS: BestFirstVisitor<N, T, BV>,
     {
         let mut queue: BinaryHeap<WeightedValue<N, Self::Node>> = BinaryHeap::new();
+        // The lowest cost collision with actual scene geometry.
         let mut best_cost = N::max_value();
         let mut best_result = None;
 
@@ -112,6 +113,7 @@ pub trait BVH<T, BV> {
 
             match visitor.visit(best_cost, root_bv, root_data) {
                 BestFirstVisitStatus::Continue { cost, result } => {
+                    // Root may be a leaf node
                     if let Some(res) = result {
                         best_cost = cost;
                         best_result = Some((root, res));
@@ -125,6 +127,7 @@ pub trait BVH<T, BV> {
 
             while let Some(entry) = queue.pop() {
                 if -entry.cost >= best_cost {
+                    // No BV left in the tree that has a lower cost than best_result
                     break; // Solution found.
                 }
 
@@ -136,10 +139,11 @@ pub trait BVH<T, BV> {
                         BestFirstVisitStatus::Continue { cost, result } => {
                             if cost < best_cost {
                                 if result.is_some() {
+                                    // This is the nearest collision so far
                                     best_cost = cost;
                                     best_result = result.map(|res| (child, res));
                                 }
-
+                                // BV may have a child with lower cost, evaluate it next.
                                 queue.push(WeightedValue::new(child, -cost))
                             }
                         }

--- a/src/query/visitors/ray_intersection_cost_fn_visitor.rs
+++ b/src/query/visitors/ray_intersection_cost_fn_visitor.rs
@@ -77,8 +77,11 @@ where
 
             // If the node has data then it is a leaf
             if let Some(data_handle) = data {
-                // all objects within the tree must be further away than the
-                // bounding volume (TODO: is this true?)
+                // rough_toi is less than or equal the cost of any subnode.
+                // Either: The ray origin is outside the bv, and so no point in the bv
+                //   could have a lower cost than rough_toi.
+                // Or: The ray origin is inside the bv, and rough_toi is 0
+                // We only check the data if it may be better than best_cost_so_far
                 if rough_toi < best_cost_so_far {
                     // Possibly the best. Look up underlying data of the node...
                     // TODO: Should this be `.expect()`?


### PR DESCRIPTION
Trying to familiarize myself with the library, I spent some time trying to understand best_first_search so commented and cleaned it up a bit. Only a slight functional change, where previously leaf nodes would be added to the heap then immediately popped and discarded.

Additionally, add simple testcase for first_interference_with_ray, based on interferences_with_ray.