### PR TITLE
Add some tweaks to improve robustness when using fixed-point numbers.

### DIFF
--- a/build/ncollide2d/Cargo.toml
+++ b/build/ncollide2d/Cargo.toml
@@ -17,6 +17,10 @@ default = [ "dim2" ]
 dim2    = [ ]
 serde-serialize = [ "serde", "nalgebra/serde-serialize" ]
 
+# Improve numerical stability when working with fixed-point numbers
+# so we don't need a too large number of decimals.
+improved_fixed_point_support = [ ]
+
 [lib]
 name = "ncollide2d"
 path = "../../src/lib.rs"

--- a/build/ncollide3d/Cargo.toml
+++ b/build/ncollide3d/Cargo.toml
@@ -17,6 +17,10 @@ default = [ "dim3" ]
 dim3    = [ ]
 serde-serialize = [ "serde", "nalgebra/serde-serialize" ]
 
+# Improve numerical stability when working with fixed-point numbers
+# so we don't need a too large number of decimals.
+improved_fixed_point_support = [ ]
+
 [lib]
 name = "ncollide3d"
 path = "../../src/lib.rs"

--- a/src/query/algorithms/epa3.rs
+++ b/src/query/algorithms/epa3.rs
@@ -403,6 +403,12 @@ impl<N: RealField> EPA<N> {
                 }
             }
 
+            if first_new_face_id == self.faces.len() {
+                // Something went very wrong because all the edges
+                // from the silhouette belonged to deleted faces.
+                return None;
+            }
+
             self.faces[first_new_face_id].adj[2] = self.faces.len() - 1;
             self.faces.last_mut().unwrap().adj[1] = first_new_face_id;
 

--- a/src/query/algorithms/gjk.rs
+++ b/src/query/algorithms/gjk.rs
@@ -93,7 +93,15 @@ where
 
     // FIXME: reset the simplex if it is empty?
     let mut proj = simplex.project_origin_and_reduce();
-    let mut old_dir = -Unit::new_normalize(proj.coords);
+
+    let mut old_dir;
+
+    if let Some(proj_dir) = Unit::try_new(proj.coords, N::zero()) {
+        old_dir = -proj_dir;
+    } else {
+        return GJKResult::Intersection;
+    }
+
     let mut max_bound = N::max_value();
     let mut dir;
     let mut niter = 0;

--- a/src/query/closest_points/closest_points_ball_ball.rs
+++ b/src/query/closest_points/closest_points_ball_ball.rs
@@ -20,12 +20,11 @@ pub fn closest_points_ball_ball<N: RealField>(
     let r1 = b1.radius();
     let r2 = b2.radius();
     let delta_pos = *center2 - *center1;
-    let distance_squared = delta_pos.norm_squared();
+    let distance = delta_pos.norm();
     let sum_radius = r1 + r2;
-    let sum_radius_with_error = sum_radius + margin;
 
-    if distance_squared <= sum_radius_with_error * sum_radius_with_error {
-        if distance_squared <= sum_radius * sum_radius {
+    if distance - margin <= sum_radius {
+        if distance <= sum_radius {
             ClosestPoints::Intersecting
         } else {
             let normal = delta_pos.normalize();

--- a/src/query/contact/contact_ball_ball.rs
+++ b/src/query/contact/contact_ball_ball.rs
@@ -20,11 +20,11 @@ pub fn contact_ball_ball<N: RealField>(
     let sum_radius_with_error = sum_radius + prediction;
 
     if distance_squared < sum_radius_with_error * sum_radius_with_error {
-        let mut normal = Unit::new_normalize(delta_pos);
-
-        if distance_squared.is_zero() {
-            normal = Vector::x_axis();
-        }
+        let normal = if !distance_squared.is_zero() {
+            Unit::new_normalize(delta_pos)
+        } else {
+            Vector::x_axis()
+        };
 
         Some(Contact::new(
             *center1 + *normal * r1,

--- a/src/query/point/point_tetrahedron.rs
+++ b/src/query/point/point_tetrahedron.rs
@@ -330,7 +330,11 @@ impl<N: RealField> PointQueryWithLocation<N> for Tetrahedron<N> {
                     // let vb = cp_ab * ap_ac - ap_ab * cp_ac;
                     // let vc = ap_ab * bp_ac - bp_ab * ap_ac;
 
-                    let normal = n.normalize();
+                    // NOTE: the normalization may fail even if the dot products
+                    // above were < 0. This happens, e.g., when we use fixed-point
+                    // numbers and there are not enough decimal bits to perform
+                    // the normalization.
+                    let normal = n.try_normalize(N::default_epsilon())?;
                     let vc = normal.dot(&ap.cross(bp));
                     let va = normal.dot(&bp.cross(cp));
                     let vb = normal.dot(&cp.cross(ap));

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -219,16 +219,21 @@ impl<N: RealField> PointQueryWithLocation<N> for Triangle<N> {
             ProjectionInfo::OnFace(face_side, va, vb, vc) => {
                 // Voronoï region of the face.
                 if DIM != 2 {
-                    let denom = _1 / (va + vb + vc);
-                    let v = vb * denom;
-                    let w = vc * denom;
-                    let bcoords = [_1 - v - w, v, w];
-                    let res = a + ab * v + ac * w;
+                    // NOTE: in some cases, numerical instability
+                    // may result in the denominator being zero
+                    // when the triangle is nearly degenerate.
+                    if va + vb + vc != N::zero() {
+                        let denom = _1 / (va + vb + vc);
+                        let v = vb * denom;
+                        let w = vc * denom;
+                        let bcoords = [_1 - v - w, v, w];
+                        let res = a + ab * v + ac * w;
 
-                    return (
-                        compute_result(pt, m * res),
-                        TrianglePointLocation::OnFace(face_side, bcoords),
-                    );
+                        return (
+                            compute_result(pt, m * res),
+                            TrianglePointLocation::OnFace(face_side, bcoords),
+                        );
+                    }
                 }
             }
         }

--- a/src/query/point/point_triangle.rs
+++ b/src/query/point/point_triangle.rs
@@ -157,7 +157,19 @@ impl<N: RealField> PointQueryWithLocation<N> for Triangle<N> {
             }
             #[cfg(feature = "dim3")]
             {
-                let n = ab.cross(&ac);
+                let n;
+
+                #[cfg(feature = "improved_fixed_point_support")]
+                {
+                    let scaled_n = ab.cross(&ac);
+                    n = scaled_n.try_normalize(N::zero()).unwrap_or(scaled_n);
+                }
+
+                #[cfg(not(feature = "improved_fixed_point_support"))]
+                {
+                    n = ab.cross(&ac);
+                }
+
                 let vc = n.dot(&ab.cross(&ap));
                 if vc < na::zero() && ab_ap >= na::zero() && ab_bp <= na::zero() {
                     return ProjectionInfo::OnAB;

--- a/src/transformation/convex_hull3.rs
+++ b/src/transformation/convex_hull3.rs
@@ -189,9 +189,25 @@ fn get_initial_mesh<N: RealField>(
     /*
      * Compute the eigenvectors to see if the input datas live on a subspace.
      */
-    let cov_mat = cov(points);
-    let eig = cov_mat.symmetric_eigen();
-    let (eigvec, eigval) = (eig.eigenvectors, eig.eigenvalues);
+    let cov_mat;
+    let eigvec;
+    let eigval;
+
+    #[cfg(not(feature = "improved_fixed_point_support"))]
+    {
+        cov_mat = cov(points);
+        let eig = cov_mat.symmetric_eigen();
+        eigvec = eig.eigenvectors;
+        eigval = eig.eigenvalues;
+    }
+
+    #[cfg(feature = "improved_fixed_point_support")]
+    {
+        cov_mat = Matrix3::identity();
+        eigvec = Matrix3::identity();
+        eigval = Vector3::repeat(N::one());
+    }
+
     let mut eigpairs = [
         (eigvec.column(0).into_owned(), eigval[0]),
         (eigvec.column(1).into_owned(), eigval[1]),


### PR DESCRIPTION
This PR adds some tweaks to various collision-detection methods in order to improve their behavior when using fixed-point numbers. Because some of these modification may have a (slightly) negative performance impact, they are only enabled when the `improved_fixed_point_support` feature of ncollide is enabled.

In order to use ncollide with fixed-point numbers, it is strongly recommented to use at least 24 bits for the decimal part. Less accuracy may result in systematic failure of some algorithms.