### PR TITLE
Dynamic dispatch helper for time-of-impact queries

### DIFF
--- a/build/ncollide2d/examples/time_of_impact_query2d.rs
+++ b/build/ncollide2d/examples/time_of_impact_query2d.rs
@@ -28,7 +28,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_will_touch = query::time_of_impact(
         &ball_pos_will_touch,
         &ball_vel2,
@@ -38,7 +39,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_wont_touch = query::time_of_impact(
         &ball_pos_wont_touch,
         &ball_vel1,
@@ -48,7 +50,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
 
     assert_eq!(toi_intersecting.map(|toi| toi.toi), Some(0.0));
     println!("Toi: {:?}", toi_will_touch);

--- a/build/ncollide2d/examples/time_of_impact_query2d.rs
+++ b/build/ncollide2d/examples/time_of_impact_query2d.rs
@@ -20,6 +20,7 @@ fn main() {
     let ball_vel2 = Vector2::new(-0.5, -0.5);
 
     let toi_intersecting = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_intersecting,
         &ball_vel1,
         &ball,
@@ -31,6 +32,7 @@ fn main() {
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_will_touch,
         &ball_vel2,
         &ball,
@@ -42,6 +44,7 @@ fn main() {
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_wont_touch,
         &ball_vel1,
         &ball,

--- a/build/ncollide2d/tests/geometry/ball_ball_toi.rs
+++ b/build/ncollide2d/tests/geometry/ball_ball_toi.rs
@@ -11,6 +11,7 @@ fn test_ball_ball_toi() {
     let m2 = Isometry2::new(Vector2::new(0.0, 10.0), na::zero());
 
     let cast = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &m1,
         &Vector2::new(0.0, 10.0),
         &b,

--- a/build/ncollide2d/tests/geometry/ball_ball_toi.rs
+++ b/build/ncollide2d/tests/geometry/ball_ball_toi.rs
@@ -19,7 +19,8 @@ fn test_ball_ball_toi() {
         &b,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/build/ncollide2d/tests/geometry/time_of_impact2.rs
+++ b/build/ncollide2d/tests/geometry/time_of_impact2.rs
@@ -19,6 +19,7 @@ fn ball_cuboid_toi() {
     let ball_vel2 = Vector2::new(-0.5, -0.5);
 
     let toi_intersecting = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_intersecting,
         &ball_vel1,
         &ball,
@@ -30,6 +31,7 @@ fn ball_cuboid_toi() {
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_will_touch,
         &ball_vel2,
         &ball,
@@ -41,6 +43,7 @@ fn ball_cuboid_toi() {
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_wont_touch,
         &ball_vel1,
         &ball,
@@ -72,6 +75,7 @@ fn cuboid_cuboid_toi_issue_214() {
     let vel2 = Vector2::new(0.0, 0.0);
 
     let toi = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &pos1,
         &vel1,
         &shape1,

--- a/build/ncollide2d/tests/geometry/time_of_impact2.rs
+++ b/build/ncollide2d/tests/geometry/time_of_impact2.rs
@@ -27,7 +27,8 @@ fn ball_cuboid_toi() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_will_touch = query::time_of_impact(
         &ball_pos_will_touch,
         &ball_vel2,
@@ -37,7 +38,8 @@ fn ball_cuboid_toi() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_wont_touch = query::time_of_impact(
         &ball_pos_wont_touch,
         &ball_vel1,
@@ -47,7 +49,8 @@ fn ball_cuboid_toi() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
 
     assert_eq!(toi_intersecting.map(|toi| toi.toi), Some(0.0));
     assert!(relative_eq!(
@@ -77,6 +80,7 @@ fn cuboid_cuboid_toi_issue_214() {
         &shape2,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     assert!(toi.is_some());
 }

--- a/build/ncollide3d/examples/time_of_impact_query3d.rs
+++ b/build/ncollide3d/examples/time_of_impact_query3d.rs
@@ -20,6 +20,7 @@ fn main() {
     let ball_vel2 = Vector3::new(-0.5, -0.5, -0.5);
 
     let toi_intersecting = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_intersecting,
         &ball_vel1,
         &ball,
@@ -31,6 +32,7 @@ fn main() {
     )
     .unwrap();
     let toi_will_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_will_touch,
         &ball_vel2,
         &ball,
@@ -42,6 +44,7 @@ fn main() {
     )
     .unwrap();
     let toi_wont_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_wont_touch,
         &ball_vel1,
         &ball,

--- a/build/ncollide3d/examples/time_of_impact_query3d.rs
+++ b/build/ncollide3d/examples/time_of_impact_query3d.rs
@@ -28,7 +28,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_will_touch = query::time_of_impact(
         &ball_pos_will_touch,
         &ball_vel2,
@@ -38,7 +39,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
     let toi_wont_touch = query::time_of_impact(
         &ball_pos_wont_touch,
         &ball_vel1,
@@ -48,7 +50,8 @@ fn main() {
         &cuboid,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
 
     assert_eq!(toi_intersecting.map(|toi| toi.toi), Some(0.0));
     assert!(toi_will_touch.is_some() && toi_will_touch.unwrap().toi > 0.0);

--- a/build/ncollide3d/tests/geometry/ball_ball_toi.rs
+++ b/build/ncollide3d/tests/geometry/ball_ball_toi.rs
@@ -11,6 +11,7 @@ fn test_ball_ball_toi() {
     let m2 = Isometry3::new(Vector3::new(0.0, 10.0, 0.0), na::zero());
 
     let cast = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &m1,
         &Vector3::new(0.0, 10.0, 0.0),
         &b,

--- a/build/ncollide3d/tests/geometry/ball_ball_toi.rs
+++ b/build/ncollide3d/tests/geometry/ball_ball_toi.rs
@@ -19,7 +19,8 @@ fn test_ball_ball_toi() {
         &b,
         std::f64::MAX,
         0.0,
-    );
+    )
+    .unwrap();
 
     assert_eq!(cast.unwrap().toi, 0.9);
 }

--- a/build/ncollide3d/tests/geometry/ball_triangle_toi.rs
+++ b/build/ncollide3d/tests/geometry/ball_triangle_toi.rs
@@ -17,7 +17,8 @@ fn ball_triangle_toi_infinite_loop_issue() {
     let m2 = Isometry3::new(Vector3::new(11.5, 5.5, 0.0), na::zero());
     let dir = Vector3::new(0.0, 0.000000000000000000000000000000000000000006925, 0.0);
 
-    let cast = query::time_of_impact(&m1, &dir, &b, &m2, &na::zero(), &t, std::f32::MAX, 0.0);
+    let cast =
+        query::time_of_impact(&m1, &dir, &b, &m2, &na::zero(), &t, std::f32::MAX, 0.0).unwrap();
 
     println!("TOI: {:?}", cast);
     assert!(cast.is_none()); // The provided velocity is too small.

--- a/build/ncollide3d/tests/geometry/ball_triangle_toi.rs
+++ b/build/ncollide3d/tests/geometry/ball_triangle_toi.rs
@@ -17,8 +17,18 @@ fn ball_triangle_toi_infinite_loop_issue() {
     let m2 = Isometry3::new(Vector3::new(11.5, 5.5, 0.0), na::zero());
     let dir = Vector3::new(0.0, 0.000000000000000000000000000000000000000006925, 0.0);
 
-    let cast =
-        query::time_of_impact(&m1, &dir, &b, &m2, &na::zero(), &t, std::f32::MAX, 0.0).unwrap();
+    let cast = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
+        &m1,
+        &dir,
+        &b,
+        &m2,
+        &na::zero(),
+        &t,
+        std::f32::MAX,
+        0.0,
+    )
+    .unwrap();
 
     println!("TOI: {:?}", cast);
     assert!(cast.is_none()); // The provided velocity is too small.

--- a/build/ncollide3d/tests/geometry/still_objects_toi.rs
+++ b/build/ncollide3d/tests/geometry/still_objects_toi.rs
@@ -1,5 +1,5 @@
 use na::{self, Isometry3, Vector3};
-use ncollide3d::query::time_of_impact;
+use ncollide3d::query::{time_of_impact, DefaultTOIDispatcher};
 use ncollide3d::shape::Cuboid;
 
 /**
@@ -26,6 +26,7 @@ fn collide(v_y: f32) -> Option<f32> {
     let cuboid = Cuboid::new(Vector3::new(0.5, 0.5, 0.5));
 
     time_of_impact(
+        &DefaultTOIDispatcher,
         &pos1,
         &vel1,
         &cuboid,

--- a/build/ncollide3d/tests/geometry/still_objects_toi.rs
+++ b/build/ncollide3d/tests/geometry/still_objects_toi.rs
@@ -35,6 +35,7 @@ fn collide(v_y: f32) -> Option<f32> {
         std::f32::MAX,
         0.0,
     )
+    .unwrap()
     .map(|toi| toi.toi)
 }
 

--- a/build/ncollide3d/tests/geometry/time_of_impact3.rs
+++ b/build/ncollide3d/tests/geometry/time_of_impact3.rs
@@ -19,6 +19,7 @@ fn ball_cuboid_toi() {
     let ball_vel2 = Vector3::new(-0.5, -0.5, -0.5);
 
     let toi_intersecting = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_intersecting,
         &ball_vel1,
         &ball,
@@ -31,6 +32,7 @@ fn ball_cuboid_toi() {
     .unwrap()
     .map(|toi| toi.toi);
     let toi_will_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_will_touch,
         &ball_vel2,
         &ball,
@@ -43,6 +45,7 @@ fn ball_cuboid_toi() {
     .unwrap()
     .map(|toi| toi.toi);
     let toi_wont_touch = query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &ball_pos_wont_touch,
         &ball_vel1,
         &ball,

--- a/build/ncollide3d/tests/geometry/time_of_impact3.rs
+++ b/build/ncollide3d/tests/geometry/time_of_impact3.rs
@@ -28,6 +28,7 @@ fn ball_cuboid_toi() {
         std::f64::MAX,
         0.0,
     )
+    .unwrap()
     .map(|toi| toi.toi);
     let toi_will_touch = query::time_of_impact(
         &ball_pos_will_touch,
@@ -39,6 +40,7 @@ fn ball_cuboid_toi() {
         std::f64::MAX,
         0.0,
     )
+    .unwrap()
     .map(|toi| toi.toi);
     let toi_wont_touch = query::time_of_impact(
         &ball_pos_wont_touch,
@@ -50,6 +52,7 @@ fn ball_cuboid_toi() {
         std::f64::MAX,
         0.0,
     )
+    .unwrap()
     .map(|toi| toi.toi);
 
     assert_eq!(toi_intersecting, Some(0.0));

--- a/build/ncollide3d/tests/geometry/trimesh_trimesh_toi.rs
+++ b/build/ncollide3d/tests/geometry/trimesh_trimesh_toi.rs
@@ -37,6 +37,7 @@ fn do_toi_test() -> Option<f64> {
     let vel_two = Vector3::new(0.0, 0.0, 0.0);
 
     query::time_of_impact(
+        &query::DefaultTOIDispatcher,
         &transform_one,
         &vel_one,
         &shape_one,

--- a/build/ncollide3d/tests/geometry/trimesh_trimesh_toi.rs
+++ b/build/ncollide3d/tests/geometry/trimesh_trimesh_toi.rs
@@ -46,6 +46,7 @@ fn do_toi_test() -> Option<f64> {
         std::f64::MAX,
         0.0,
     )
+    .unwrap()
     .map(|toi| toi.toi)
 }
 

--- a/src/pipeline/world.rs
+++ b/src/pipeline/world.rs
@@ -330,6 +330,7 @@ impl<N: RealField, T> CollisionWorld<N, T> {
                 N::max_value(),
                 N::zero(),
             )
+            .unwrap_or(None)
             .map(|toi| (handle, toi))
         })
     }

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -1,0 +1,13 @@
+use std::fmt;
+
+/// Error indicating that a query is not supported between certain shapes
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Unsupported;
+
+impl fmt::Display for Unsupported {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("query not supported between these shapes")
+    }
+}
+
+impl std::error::Error for Unsupported {}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -28,6 +28,7 @@
 pub use self::closest_points::*;
 pub use self::contact::*;
 pub use self::distance::*;
+pub use self::error::*;
 pub use self::nonlinear_time_of_impact::*;
 pub use self::point::*;
 pub use self::proximity::*;
@@ -38,6 +39,7 @@ pub mod algorithms;
 mod closest_points;
 mod contact;
 mod distance;
+mod error;
 mod nonlinear_time_of_impact;
 mod point;
 mod proximity;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -34,6 +34,7 @@ pub use self::point::*;
 pub use self::proximity::*;
 pub use self::ray::*;
 pub use self::time_of_impact::*;
+pub use self::toi_dispatcher::*;
 
 pub mod algorithms;
 mod closest_points;
@@ -45,4 +46,5 @@ mod point;
 mod proximity;
 mod ray;
 mod time_of_impact;
+mod toi_dispatcher;
 pub mod visitors;

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact.rs
@@ -1,14 +1,15 @@
 use na::RealField;
 
 use crate::interpolation::RigidMotion;
-use crate::query::{self, Unsupported, TOI};
+use crate::query::{self, TOIDispatcher, Unsupported, TOI};
 use crate::shape::{Ball, Shape};
 
 /// Computes the smallest time of impact of two shapes under translational movement.
 pub fn nonlinear_time_of_impact<N: RealField>(
-    motion1: &(impl RigidMotion<N> + ?Sized),
+    dispatcher: &dyn TOIDispatcher<N>,
+    motion1: &dyn RigidMotion<N>,
     g1: &dyn Shape<N>,
-    motion2: &(impl RigidMotion<N> + ?Sized),
+    motion2: &dyn RigidMotion<N>,
     g2: &dyn Shape<N>,
     max_toi: N,
     target_distance: N,
@@ -33,6 +34,7 @@ pub fn nonlinear_time_of_impact<N: RealField>(
         ))
     } else if let Some(c1) = g1.as_composite_shape() {
         Ok(query::nonlinear_time_of_impact_composite_shape_shape(
+            dispatcher,
             motion1,
             c1,
             motion2,
@@ -42,6 +44,7 @@ pub fn nonlinear_time_of_impact<N: RealField>(
         ))
     } else if let Some(c2) = g2.as_composite_shape() {
         Ok(query::nonlinear_time_of_impact_shape_composite_shape(
+            dispatcher,
             motion1,
             g1,
             motion2,

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact.rs
@@ -1,7 +1,7 @@
 use na::RealField;
 
 use crate::interpolation::RigidMotion;
-use crate::query::{self, TOI};
+use crate::query::{self, Unsupported, TOI};
 use crate::shape::{Ball, Shape};
 
 /// Computes the smallest time of impact of two shapes under translational movement.
@@ -12,43 +12,43 @@ pub fn nonlinear_time_of_impact<N: RealField>(
     g2: &dyn Shape<N>,
     max_toi: N,
     target_distance: N,
-) -> Option<TOI<N>> {
+) -> Result<Option<TOI<N>>, Unsupported> {
     if let (Some(b1), Some(b2)) = (g1.as_shape::<Ball<N>>(), g2.as_shape::<Ball<N>>()) {
-        query::nonlinear_time_of_impact_ball_ball(
+        Ok(query::nonlinear_time_of_impact_ball_ball(
             motion1,
             b1,
             motion2,
             b2,
             max_toi,
             target_distance,
-        )
+        ))
     } else if let (Some(s1), Some(s2)) = (g1.as_support_map(), g2.as_support_map()) {
-        query::nonlinear_time_of_impact_support_map_support_map(
+        Ok(query::nonlinear_time_of_impact_support_map_support_map(
             motion1,
             s1,
             motion2,
             s2,
             max_toi,
             target_distance,
-        )
+        ))
     } else if let Some(c1) = g1.as_composite_shape() {
-        query::nonlinear_time_of_impact_composite_shape_shape(
+        Ok(query::nonlinear_time_of_impact_composite_shape_shape(
             motion1,
             c1,
             motion2,
             g2,
             max_toi,
             target_distance,
-        )
+        ))
     } else if let Some(c2) = g2.as_composite_shape() {
-        query::nonlinear_time_of_impact_shape_composite_shape(
+        Ok(query::nonlinear_time_of_impact_shape_composite_shape(
             motion1,
             g1,
             motion2,
             c2,
             max_toi,
             target_distance,
-        )
+        ))
     /* } else if let (Some(p1), Some(s2)) = (g1.as_shape::<Plane<N>>(), g2.as_support_map()) {
     //        query::nonlinear_time_of_impact_plane_support_map(m1, vel1, p1, m2, vel2, s2)
             unimplemented!()
@@ -56,9 +56,6 @@ pub fn nonlinear_time_of_impact<N: RealField>(
     //        query::nonlinear_time_of_impact_support_map_plane(m1, vel1, s1, m2, vel2, p2)
             unimplemented!() */
     } else {
-        eprintln!(
-            "No algorithm known to compute a contact point between the given pair of shapes."
-        );
-        None
+        Err(Unsupported)
     }
 }

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
@@ -151,7 +151,9 @@ where
                                 self.g2,
                                 self.max_toi,
                                 self.target_distance,
-                            ) {
+                            )
+                            .unwrap_or(None)
+                            {
                                 res = BestFirstVisitStatus::Continue {
                                     cost: toi.toi,
                                     result: Some(toi),

--- a/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
+++ b/src/query/nonlinear_time_of_impact/nonlinear_time_of_impact_composite_shape_shape.rs
@@ -2,15 +2,16 @@ use crate::bounding_volume::{BoundingSphere, AABB};
 use crate::interpolation::{RigidMotion, RigidMotionComposition};
 use crate::math::Isometry;
 use crate::partitioning::{BestFirstVisitStatus, BestFirstVisitor};
-use crate::query::{self, TOI};
+use crate::query::{self, TOIDispatcher, TOI};
 use crate::shape::{Ball, CompositeShape, Shape};
 use na::{self, RealField};
 
 /// Time Of Impact of a composite shape with any other shape, under a rigid motion (translation + rotation).
 pub fn nonlinear_time_of_impact_composite_shape_shape<N, G1>(
-    motion1: &(impl RigidMotion<N> + ?Sized),
+    dispatcher: &dyn TOIDispatcher<N>,
+    motion1: &dyn RigidMotion<N>,
     g1: &G1,
-    motion2: &(impl RigidMotion<N> + ?Sized),
+    motion2: &dyn RigidMotion<N>,
     g2: &dyn Shape<N>,
     max_toi: N,
     target_distance: N,
@@ -20,6 +21,7 @@ where
     G1: ?Sized + CompositeShape<N>,
 {
     let mut visitor = CompositeShapeAgainstAnyNonlinearTOIVisitor::new(
+        dispatcher,
         motion1,
         g1,
         motion2,
@@ -33,9 +35,10 @@ where
 
 /// Time Of Impact of any shape with a composite shape, under a rigid motion (translation + rotation).
 pub fn nonlinear_time_of_impact_shape_composite_shape<N, G2>(
-    motion1: &(impl RigidMotion<N> + ?Sized),
+    dispatcher: &dyn TOIDispatcher<N>,
+    motion1: &dyn RigidMotion<N>,
     g1: &dyn Shape<N>,
-    motion2: &(impl RigidMotion<N> + ?Sized),
+    motion2: &dyn RigidMotion<N>,
     g2: &G2,
     max_toi: N,
     target_distance: N,
@@ -45,6 +48,7 @@ where
     G2: ?Sized + CompositeShape<N>,
 {
     nonlinear_time_of_impact_composite_shape_shape(
+        dispatcher,
         motion2,
         g2,
         motion1,
@@ -54,39 +58,34 @@ where
     )
 }
 
-struct CompositeShapeAgainstAnyNonlinearTOIVisitor<
-    'a,
-    N: 'a + RealField,
-    G1: ?Sized + 'a,
-    M1: ?Sized,
-    M2: ?Sized,
-> {
+struct CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N: 'a + RealField, G1: ?Sized + 'a> {
+    dispatcher: &'a dyn TOIDispatcher<N>,
     sphere2: BoundingSphere<N>,
     max_toi: N,
     target_distance: N,
 
-    motion1: &'a M1,
+    motion1: &'a dyn RigidMotion<N>,
     g1: &'a G1,
-    motion2: &'a M2,
+    motion2: &'a dyn RigidMotion<N>,
     g2: &'a dyn Shape<N>,
 }
 
-impl<'a, N, G1, M1, M2> CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1, M1, M2>
+impl<'a, N, G1> CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1>
 where
     N: RealField,
     G1: ?Sized + CompositeShape<N>,
-    M1: ?Sized + RigidMotion<N>,
-    M2: ?Sized + RigidMotion<N>,
 {
     pub fn new(
-        motion1: &'a M1,
+        dispatcher: &'a dyn TOIDispatcher<N>,
+        motion1: &'a dyn RigidMotion<N>,
         g1: &'a G1,
-        motion2: &'a M2,
+        motion2: &'a dyn RigidMotion<N>,
         g2: &'a dyn Shape<N>,
         max_toi: N,
         target_distance: N,
-    ) -> CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1, M1, M2> {
+    ) -> CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1> {
         CompositeShapeAgainstAnyNonlinearTOIVisitor {
+            dispatcher,
             sphere2: g2.bounding_sphere(&Isometry::identity()),
             max_toi,
             target_distance,
@@ -98,13 +97,11 @@ where
     }
 }
 
-impl<'a, N, G1, M1, M2> BestFirstVisitor<N, usize, AABB<N>>
-    for CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1, M1, M2>
+impl<'a, N, G1> BestFirstVisitor<N, usize, AABB<N>>
+    for CompositeShapeAgainstAnyNonlinearTOIVisitor<'a, N, G1>
 where
     N: RealField,
     G1: ?Sized + CompositeShape<N>,
-    M1: ?Sized + RigidMotion<N>,
-    M2: ?Sized + RigidMotion<N>,
 {
     type Result = TOI<N>;
 
@@ -142,17 +139,18 @@ where
                         .map_part_at(*b, &Isometry::identity(), &mut |m1, g1| {
                             let motion1 = self.motion1.prepend_transformation(*m1);
 
-                            // NOTE: we have to use a trait-object for `&motion1 as &RigidMotion<N>` to avoid infinite
-                            // compiler recursion when it monomorphizes query::nonlinear_time_of_impact.
-                            if let Some(toi) = query::nonlinear_time_of_impact(
-                                &motion1 as &dyn RigidMotion<N>,
-                                g1,
-                                self.motion2,
-                                self.g2,
-                                self.max_toi,
-                                self.target_distance,
-                            )
-                            .unwrap_or(None)
+                            if let Some(toi) = self
+                                .dispatcher
+                                .nonlinear_time_of_impact(
+                                    self.dispatcher,
+                                    &motion1,
+                                    g1,
+                                    self.motion2,
+                                    self.g2,
+                                    self.max_toi,
+                                    self.target_distance,
+                                )
+                                .unwrap_or(None)
                             {
                                 res = BestFirstVisitStatus::Continue {
                                     cost: toi.toi,

--- a/src/query/time_of_impact/time_of_impact.rs
+++ b/src/query/time_of_impact/time_of_impact.rs
@@ -1,7 +1,7 @@
 use na::{RealField, Unit};
 
 use crate::math::{Isometry, Point, Vector};
-use crate::query::{self, Unsupported};
+use crate::query::{self, TOIDispatcher, Unsupported};
 use crate::shape::{Ball, Plane, Shape};
 use crate::utils::IsometryOps;
 
@@ -64,6 +64,7 @@ impl<N: RealField> TOI<N> {
 ///
 /// Returns `0.0` if the objects are touching or penetrating.
 pub fn time_of_impact<N: RealField>(
+    dispatcher: &dyn TOIDispatcher<N>,
     m1: &Isometry<N>,
     vel1: &Vector<N>,
     g1: &dyn Shape<N>,
@@ -127,6 +128,7 @@ pub fn time_of_impact<N: RealField>(
         ))
     } else if let Some(c1) = g1.as_composite_shape() {
         Ok(query::time_of_impact_composite_shape_shape(
+            dispatcher,
             m1,
             vel1,
             c1,
@@ -138,6 +140,7 @@ pub fn time_of_impact<N: RealField>(
         ))
     } else if let Some(c2) = g2.as_composite_shape() {
         Ok(query::time_of_impact_shape_composite_shape(
+            dispatcher,
             m1,
             vel1,
             g1,

--- a/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
+++ b/src/query/time_of_impact/time_of_impact_composite_shape_shape.rs
@@ -149,7 +149,9 @@ where
                             self.g2,
                             self.max_toi,
                             self.target_distance,
-                        ) {
+                        )
+                        .unwrap_or(None)
+                        {
                             if toi.toi > self.max_toi {
                                 res = BestFirstVisitStatus::Stop;
                             } else {

--- a/src/query/toi_dispatcher.rs
+++ b/src/query/toi_dispatcher.rs
@@ -1,0 +1,143 @@
+use na::RealField;
+
+use crate::interpolation::RigidMotion;
+use crate::math::{Isometry, Vector};
+use crate::query::{self, Unsupported, TOI};
+use crate::shape::Shape;
+
+/// Dispatcher for time-of-impact queries
+///
+/// Custom implementations allow crates that support an abstract `TOIDispatcher` to handle custom
+/// shapes. Methods take `root_dispatcher` to allow dispatchers to delegate to eachother. Callers
+/// that will not themselves be used to implement a `TOIDispatcher` should pass `self`.
+pub trait TOIDispatcher<N: RealField>: Send + Sync {
+    /// Computes the smallest time of impact of two shapes under translational movement.
+    fn nonlinear_time_of_impact(
+        &self,
+        root_dispatcher: &dyn TOIDispatcher<N>,
+        motion1: &dyn RigidMotion<N>,
+        g1: &dyn Shape<N>,
+        motion2: &dyn RigidMotion<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Result<Option<TOI<N>>, Unsupported>;
+
+    /// Computes the smallest time at with two shapes under translational movement are separated by a
+    /// distance smaller or equal to `distance`.
+    ///
+    /// Returns `0.0` if the objects are touching or penetrating.
+    fn time_of_impact(
+        &self,
+        root_dispatcher: &dyn TOIDispatcher<N>,
+        m1: &Isometry<N>,
+        vel1: &Vector<N>,
+        g1: &dyn Shape<N>,
+        m2: &Isometry<N>,
+        vel2: &Vector<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Result<Option<TOI<N>>, Unsupported>;
+
+    /// Construct a `TOIDispatcher` that falls back on `other` for cases not handled by `self`
+    fn chain<U: TOIDispatcher<N>>(self, other: U) -> Chain<Self, U>
+    where
+        Self: Sized,
+    {
+        Chain(self, other)
+    }
+}
+
+/// A dispatcher that exposes built-in queries
+#[derive(Debug, Clone)]
+pub struct DefaultTOIDispatcher;
+
+impl<N: RealField> TOIDispatcher<N> for DefaultTOIDispatcher {
+    fn nonlinear_time_of_impact(
+        &self,
+        root_dispatcher: &dyn TOIDispatcher<N>,
+        motion1: &dyn RigidMotion<N>,
+        g1: &dyn Shape<N>,
+        motion2: &dyn RigidMotion<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Result<Option<TOI<N>>, Unsupported> {
+        query::nonlinear_time_of_impact(
+            root_dispatcher,
+            motion1,
+            g1,
+            motion2,
+            g2,
+            max_toi,
+            target_distance,
+        )
+    }
+
+    fn time_of_impact(
+        &self,
+        root_dispatcher: &dyn TOIDispatcher<N>,
+        m1: &Isometry<N>,
+        vel1: &Vector<N>,
+        g1: &dyn Shape<N>,
+        m2: &Isometry<N>,
+        vel2: &Vector<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Result<Option<TOI<N>>, Unsupported> {
+        query::time_of_impact(
+            root_dispatcher,
+            m1,
+            vel1,
+            g1,
+            m2,
+            vel2,
+            g2,
+            max_toi,
+            target_distance,
+        )
+    }
+}
+
+/// The composition of two dispatchers
+pub struct Chain<T, U>(T, U);
+
+macro_rules! chain_method {
+    ($name:ident ( $( $arg:ident : $ty:ty,)*) -> $result:ty) => {
+        fn $name(&self, root_dispatcher: &dyn TOIDispatcher<N>,
+                 $($arg : $ty,)*
+        ) -> Result<$result, Unsupported> {
+            (self.0).$name(root_dispatcher, $($arg,)*)
+                .or_else(|Unsupported| (self.1).$name(root_dispatcher, $($arg,)*))
+        }
+    }
+}
+
+impl<N, T, U> TOIDispatcher<N> for Chain<T, U>
+where
+    N: RealField,
+    T: TOIDispatcher<N>,
+    U: TOIDispatcher<N>,
+{
+    chain_method!(nonlinear_time_of_impact(
+        motion1: &dyn RigidMotion<N>,
+        g1: &dyn Shape<N>,
+        motion2: &dyn RigidMotion<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Option<TOI<N>>);
+
+    chain_method!(time_of_impact(
+        m1: &Isometry<N>,
+        vel1: &Vector<N>,
+        g1: &dyn Shape<N>,
+        m2: &Isometry<N>,
+        vel2: &Vector<N>,
+        g2: &dyn Shape<N>,
+        max_toi: N,
+        target_distance: N,
+    ) -> Option<TOI<N>>);
+}


### PR DESCRIPTION
This provides a foundation for nphysics to support CCD on custom shapes, and for downstream crates to conveniently compose dispatchers. This requirement is motivated by my work in [planetmap](https://github.com/Ralith/planetmap) to provide collision detection for streaming spherical terrain, which requires close integration with ncollide queries to be efficient, much like heightfields do.

While this could be merged as-is, there's one question I'd like feedback on: should we fold `ContactDispatcher` and `ProximityDispatcher` into this trait? A single trait object is more convenient (particularly for composition), and in general anyone seeking to implement a custom shape will probably want to support everything, or at least be fully conscious of any unsupported operations.