### PR TITLE
Add empty CollisionGroups ctor, and option to replace masks entirely

### DIFF
--- a/src/pipeline/object/collision_groups.rs
+++ b/src/pipeline/object/collision_groups.rs
@@ -59,6 +59,16 @@ impl CollisionGroups {
         }
     }
 
+    /// Creates a new `CollisionGroups` that disables interactions with everything.
+    #[inline]
+    pub fn empty() -> CollisionGroups {
+        CollisionGroups {
+            membership: NO_GROUP,
+            whitelist: NO_GROUP,
+            blacklist: NO_GROUP,
+        }
+    }
+
     /// Returns a copy of this object, updated with a new set of membership groups.
     ///
     /// # Examples
@@ -173,6 +183,18 @@ impl CollisionGroups {
     }
 
     #[inline]
+    /// Replaces the membership with a mask of bits where each bit index represent a group
+    pub fn with_membership_by_mask(mut self, group_mask: u32) -> CollisionGroups {
+        assert!(
+            group_mask <= ALL_GROUPS,
+            "There are at most 30 groups indexed from 0 to 29 (included)."
+        );
+
+        self.membership = group_mask;
+        self
+    }
+
+    #[inline]
     /// adds this entity to this entity whitelist by a mask of bits where each bit index represent a group
     pub fn add_whitelist_by_mask(mut self, group_mask: u32) -> CollisionGroups {
         self.whitelist = Self::add_mask(self.whitelist, group_mask);
@@ -187,6 +209,18 @@ impl CollisionGroups {
     }
 
     #[inline]
+    /// Replaces the whitelist with a mask of bits where each bit index represent a group
+    pub fn with_whitelist_by_mask(mut self, group_mask: u32) -> CollisionGroups {
+        assert!(
+            group_mask <= ALL_GROUPS,
+            "There are at most 30 groups indexed from 0 to 29 (included)."
+        );
+
+        self.whitelist = group_mask;
+        self
+    }
+
+    #[inline]
     /// adds this entity to this entity blacklist by a mask of bits where each bit index represent a group
     pub fn add_blacklist_by_mask(mut self, group_mask: u32) -> CollisionGroups {
         self.blacklist = Self::add_mask(self.blacklist, group_mask);
@@ -197,6 +231,18 @@ impl CollisionGroups {
     /// remove this entity from this entity blacklist by a mask of bits where each bit index represent a group
     pub fn remove_blacklist_by_mask(mut self, group_mask: u32) -> CollisionGroups {
         self.blacklist = Self::remove_mask(self.blacklist, group_mask);
+        self
+    }
+
+    #[inline]
+    /// Replaces the blacklist with a mask of bits where each bit index represent a group
+    pub fn with_blacklist_by_mask(mut self, group_mask: u32) -> CollisionGroups {
+        assert!(
+            group_mask <= ALL_GROUPS,
+            "There are at most 30 groups indexed from 0 to 29 (included)."
+        );
+
+        self.blacklist = group_mask;
         self
     }
 


### PR DESCRIPTION
This should make it easier to create `CollisionGroups` values from scratch using bitmasks. This is a further extension of #331.